### PR TITLE
fix(validation): enforce DNS-label constraints on app names and env var names

### DIFF
--- a/internal/mcp/resources/application_spec.go
+++ b/internal/mcp/resources/application_spec.go
@@ -80,8 +80,15 @@ func RegisterApplicationSpec(server *gomcp.Server, deps *tools.Dependencies) {
 			},
 			"status": map[string]any{
 				"phase": map[string]any{
-					"type":   "string",
-					"enum":   []string{"Pending", "Building", "Deploying", "Running", "Failed"},
+					"type": "string",
+					"enum": []string{"Pending", "Building", "Deploying", "Running", "Failed"},
+					"phaseDescriptions": map[string]string{
+						"Pending":   "Application is accepted; waiting for controller to start processing.",
+						"Building":  "Source code or git repo is being built into a container image by kpack.",
+						"Deploying": "Image is resolved; Deployment is created; waiting for at least one pod replica to become available. URL is set.",
+						"Running":   "At least one pod replica is available and serving traffic.",
+						"Failed":    "Build or deployment has failed. Check buildStatus and conditions for details.",
+					},
 					"description": "Current lifecycle phase of the application.",
 				},
 				"url": map[string]any{


### PR DESCRIPTION
## Summary

- New `internal/validation` package with `ValidateAppName` and `ValidateEnvVarName` functions
- All MCP tools (`deploy_app`, `push_code`, `app_status`, `app_logs`, `delete_app`) validate app names before any K8s operation
- REST `Create` and `Update` handlers validate app name and env var names, returning HTTP 400 with a JSON error body
- `app_status` now returns `"sourceType": "code"` when `Spec.Blob` is set (was `"blob"`), matching `list_apps`
- `sourcestore.StoreFiles` path traversal check hardened with join-and-confirm approach (eliminates false positives on filenames like `..secret`)
- `iaf://schema/application` resource updated to document `Deploying` phase meaning

## Test plan
- [ ] `go test ./internal/validation/... -v` — all table-driven cases pass
- [ ] `go test ./internal/... -v` — all packages green
- [ ] Invalid app names return descriptive errors (not opaque K8s errors)
- [ ] Reserved prefixes `kube-` and `iaf-` are rejected

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)