### PR TITLE
feat(controller): create application controller with Deploying phase lifecycle

### DIFF
--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -1,0 +1,378 @@
+// Package controller implements the Application CRD controller.
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	iafv1alpha1 "github.com/dlapiduz/iaf/api/v1alpha1"
+	iafk8s "github.com/dlapiduz/iaf/internal/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// +kubebuilder:rbac:groups=iaf.io,resources=applications,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=iaf.io,resources=applications/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=iaf.io,resources=applications/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kpack.io,resources=images,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=traefik.io,resources=ingressroutes,verbs=get;list;watch;create;update;patch;delete
+
+// ApplicationReconciler reconciles Application CRs.
+type ApplicationReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	ClusterBuilder string
+	RegistryPrefix string
+	BaseDomain     string
+}
+
+// Reconcile is the main reconciliation loop for Application CRs.
+func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var app iafv1alpha1.Application
+	if err := r.Get(ctx, req.NamespacedName, &app); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("getting application: %w", err)
+	}
+
+	// Resolve the container image to deploy.
+	image, buildStatus, err := r.resolveImage(ctx, &app)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// If we are still waiting for a build, update build status and requeue.
+	if image == "" {
+		if err := r.setBuildingStatus(ctx, &app, buildStatus); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	// Set Deploying phase before creating/updating the Deployment (if not already past that).
+	if app.Status.Phase == iafv1alpha1.ApplicationPhaseBuilding ||
+		app.Status.Phase == iafv1alpha1.ApplicationPhasePending ||
+		app.Status.Phase == "" {
+		if err := r.setDeployingPhaseOnly(ctx, &app); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Create or update the Deployment, Service, and IngressRoute.
+	dep, err := r.reconcileDeployment(ctx, &app, image)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.reconcileService(ctx, &app); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.reconcileIngressRoute(ctx, &app); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update status based on current Deployment availability.
+	return r.reconcileStatus(ctx, &app, image, buildStatus, dep)
+}
+
+// resolveImage returns the container image to deploy.
+// For pre-built images, it returns immediately. For kpack builds, it reads
+// the kpack Image CR status. Returns ("", ...) while the build is in progress.
+func (r *ApplicationReconciler) resolveImage(ctx context.Context, app *iafv1alpha1.Application) (image, buildStatus string, err error) {
+	if app.Spec.Image != "" {
+		return app.Spec.Image, "NotRequired", nil
+	}
+
+	if app.Spec.Git == nil && app.Spec.Blob == "" {
+		return "", "Unknown", fmt.Errorf("application %q has no image, git, or blob source", app.Name)
+	}
+
+	// Ensure kpack Image CR exists.
+	kpackImage := iafk8s.BuildKpackImage(app, r.ClusterBuilder, r.RegistryPrefix)
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(iafk8s.KpackImageGVK)
+	err = r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", "", fmt.Errorf("getting kpack image: %w", err)
+		}
+		if err := r.Create(ctx, kpackImage); err != nil && !apierrors.IsAlreadyExists(err) {
+			return "", "", fmt.Errorf("creating kpack image: %w", err)
+		}
+		return "", "Building", nil
+	}
+
+	// Update source URL if the blob changed (re-push).
+	existingSpec, _ := existing.Object["spec"].(map[string]any)
+	newSpec := kpackImage.Object["spec"].(map[string]any)
+	existingSource, _ := existingSpec["source"].(map[string]any)
+	newSource, _ := newSpec["source"].(map[string]any)
+	if fmt.Sprintf("%v", existingSource) != fmt.Sprintf("%v", newSource) {
+		existing.Object["spec"] = newSpec
+		if err := r.Update(ctx, existing); err != nil {
+			return "", "", fmt.Errorf("updating kpack image: %w", err)
+		}
+	}
+
+	buildSt, latestImage := iafk8s.GetKpackImageStatus(existing)
+	if latestImage == "" {
+		return "", buildSt, nil
+	}
+	return latestImage, buildSt, nil
+}
+
+// setBuildingStatus updates the Application status to Building phase.
+func (r *ApplicationReconciler) setBuildingStatus(ctx context.Context, app *iafv1alpha1.Application, buildStatus string) error {
+	app.Status.Phase = iafv1alpha1.ApplicationPhaseBuilding
+	app.Status.BuildStatus = buildStatus
+	setCondition(app, "Ready", metav1.ConditionFalse, "Building", "Waiting for container image build to complete")
+	return r.Status().Update(ctx, app)
+}
+
+// setDeployingPhaseOnly sets phase to Deploying without touching AvailableReplicas.
+// Called once before reconcileDeployment to give agents an accurate intermediate state.
+func (r *ApplicationReconciler) setDeployingPhaseOnly(ctx context.Context, app *iafv1alpha1.Application) error {
+	app.Status.Phase = iafv1alpha1.ApplicationPhaseDeploying
+	setCondition(app, "Ready", metav1.ConditionFalse, "Deploying", "Waiting for pod replicas to become available")
+	return r.Status().Update(ctx, app)
+}
+
+// reconcileDeployment creates or updates the Deployment for the application.
+// Returns the current Deployment object (with up-to-date status).
+func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, app *iafv1alpha1.Application, image string) (*appsv1.Deployment, error) {
+	port := app.Spec.Port
+	if port == 0 {
+		port = 8080
+	}
+	replicas := app.Spec.Replicas
+	if replicas == 0 {
+		replicas = 1
+	}
+
+	envVars := make([]corev1.EnvVar, 0, len(app.Spec.Env))
+	for _, e := range app.Spec.Env {
+		envVars = append(envVars, corev1.EnvVar{Name: e.Name, Value: e.Value})
+	}
+
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      app.Name,
+			Namespace: app.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "iaf",
+				"iaf.io/application":          app.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: iafv1alpha1.GroupVersion.String(),
+					Kind:       "Application",
+					Name:       app.Name,
+					UID:        app.UID,
+					Controller: boolPtr(true),
+				},
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"iaf.io/application": app.Name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"iaf.io/application": app.Name},
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: boolPtr(true),
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: image,
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: port, Protocol: corev1.ProtocolTCP},
+							},
+							Env: envVars,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: boolPtr(false),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	existing := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("getting deployment: %w", err)
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			return nil, fmt.Errorf("creating deployment: %w", err)
+		}
+		// Return the just-created Deployment (status will be empty, so available=0).
+		return desired, nil
+	}
+
+	// Update the existing Deployment spec.
+	existing.Spec = desired.Spec
+	if err := r.Update(ctx, existing); err != nil {
+		return nil, fmt.Errorf("updating deployment: %w", err)
+	}
+	return existing, nil
+}
+
+// reconcileService creates or updates the Service for the application.
+func (r *ApplicationReconciler) reconcileService(ctx context.Context, app *iafv1alpha1.Application) error {
+	port := app.Spec.Port
+	if port == 0 {
+		port = 8080
+	}
+
+	desired := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      app.Name,
+			Namespace: app.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "iaf",
+				"iaf.io/application":          app.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: iafv1alpha1.GroupVersion.String(),
+					Kind:       "Application",
+					Name:       app.Name,
+					UID:        app.UID,
+					Controller: boolPtr(true),
+				},
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"iaf.io/application": app.Name},
+			Ports: []corev1.ServicePort{
+				{Port: port, Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+
+	existing := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("getting service: %w", err)
+		}
+		return r.Create(ctx, desired)
+	}
+	existing.Spec.Ports = desired.Spec.Ports
+	existing.Spec.Selector = desired.Spec.Selector
+	return r.Update(ctx, existing)
+}
+
+// reconcileIngressRoute creates or updates the Traefik IngressRoute for the application.
+func (r *ApplicationReconciler) reconcileIngressRoute(ctx context.Context, app *iafv1alpha1.Application) error {
+	desired := iafk8s.BuildIngressRoute(app, r.BaseDomain)
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(iafk8s.TraefikIngressRouteGVK)
+	err := r.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("getting ingressroute: %w", err)
+		}
+		return r.Create(ctx, desired)
+	}
+	existing.Object["spec"] = desired.Object["spec"]
+	return r.Update(ctx, existing)
+}
+
+// reconcileStatus reads the current Deployment availability and updates the Application status.
+// It sets phase to Running if at least one replica is available, or Deploying otherwise.
+func (r *ApplicationReconciler) reconcileStatus(ctx context.Context, app *iafv1alpha1.Application, image, buildStatus string, dep *appsv1.Deployment) (ctrl.Result, error) {
+	available := dep.Status.AvailableReplicas
+
+	host := app.Spec.Host
+	if host == "" {
+		host = fmt.Sprintf("%s.%s", app.Name, r.BaseDomain)
+	}
+
+	// Always write accurate status fields.
+	app.Status.AvailableReplicas = available
+	app.Status.LatestImage = image
+	app.Status.BuildStatus = buildStatus
+	app.Status.URL = fmt.Sprintf("http://%s", host)
+
+	if available >= 1 {
+		app.Status.Phase = iafv1alpha1.ApplicationPhaseRunning
+		setCondition(app, "Ready", metav1.ConditionTrue, "Available", fmt.Sprintf("%d replica(s) available", available))
+		if err := r.Status().Update(ctx, app); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating status to Running: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// No replicas available: stay in (or return to) Deploying.
+	app.Status.Phase = iafv1alpha1.ApplicationPhaseDeploying
+	setCondition(app, "Ready", metav1.ConditionFalse, "Deploying", "Waiting for pod replicas to become available")
+	if err := r.Status().Update(ctx, app); err != nil {
+		return ctrl.Result{}, fmt.Errorf("updating status to Deploying: %w", err)
+	}
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+// SetupWithManager registers the controller with the manager and configures watches.
+func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Watch kpack Image CRs so build completion triggers immediate reconciliation.
+	kpackImageType := &unstructured.Unstructured{}
+	kpackImageType.SetGroupVersionKind(iafk8s.KpackImageGVK)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&iafv1alpha1.Application{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Watches(
+			kpackImageType,
+			handler.EnqueueRequestForOwner(
+				mgr.GetScheme(),
+				mgr.GetRESTMapper(),
+				&iafv1alpha1.Application{},
+				handler.OnlyControllerOwner(),
+			),
+		).
+		Complete(r)
+}
+
+// setCondition upserts a condition on the Application status.
+func setCondition(app *iafv1alpha1.Application, condType string, status metav1.ConditionStatus, reason, message string) {
+	now := metav1.Now()
+	for i, c := range app.Status.Conditions {
+		if c.Type == condType {
+			app.Status.Conditions[i].Status = status
+			app.Status.Conditions[i].Reason = reason
+			app.Status.Conditions[i].Message = message
+			app.Status.Conditions[i].LastTransitionTime = now
+			return
+		}
+	}
+	app.Status.Conditions = append(app.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: now,
+	})
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/controller/application_controller_test.go
+++ b/internal/controller/application_controller_test.go
@@ -1,0 +1,308 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	iafv1alpha1 "github.com/dlapiduz/iaf/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := iafv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func newReconciler(scheme *runtime.Scheme, objs ...runtime.Object) *ApplicationReconciler {
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&iafv1alpha1.Application{}).
+		Build()
+
+	return &ApplicationReconciler{
+		Client:         k8sClient,
+		Scheme:         scheme,
+		ClusterBuilder: "default",
+		RegistryPrefix: "registry.example.com",
+		BaseDomain:     "example.com",
+	}
+}
+
+func makeApp(name, namespace string) *iafv1alpha1.Application {
+	return &iafv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       "test-uid",
+		},
+		Spec: iafv1alpha1.ApplicationSpec{
+			Image:    "nginx:latest",
+			Port:     8080,
+			Replicas: 1,
+		},
+	}
+}
+
+func reconcileApp(t *testing.T, r *ApplicationReconciler, name, namespace string) ctrl.Result {
+	t.Helper()
+	ctx := context.Background()
+	result, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned unexpected error: %v", err)
+	}
+	return result
+}
+
+// TestReconcile_ImageApp_SetsDeployingThenRunning verifies the phase progression
+// for a pre-built image app: Pending → Deploying after first reconcile, then
+// Running once the Deployment has available replicas.
+func TestReconcile_ImageApp_SetsDeployingThenRunning(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	app := makeApp("myapp", "test-ns")
+	if err := r.Create(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	// First reconcile: app has no Deployment yet → should set Deploying.
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var result iafv1alpha1.Application
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.Phase != iafv1alpha1.ApplicationPhaseDeploying {
+		t.Errorf("expected phase Deploying after first reconcile, got %q", result.Status.Phase)
+	}
+	if result.Status.URL == "" {
+		t.Error("expected URL to be set during Deploying phase")
+	}
+
+	// Verify a Deployment was created.
+	var dep appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &dep); err != nil {
+		t.Fatalf("expected Deployment to be created: %v", err)
+	}
+
+	// Simulate the Deployment becoming available (1 pod ready).
+	dep.Status.AvailableReplicas = 1
+	if err := r.Status().Update(ctx, &dep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second reconcile: should set Running.
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.Phase != iafv1alpha1.ApplicationPhaseRunning {
+		t.Errorf("expected phase Running after replicas available, got %q", result.Status.Phase)
+	}
+	if result.Status.AvailableReplicas != 1 {
+		t.Errorf("expected availableReplicas=1, got %d", result.Status.AvailableReplicas)
+	}
+}
+
+// TestReconcile_AvailableReplicasAlwaysAccurate verifies that availableReplicas
+// is updated on every reconcile pass.
+func TestReconcile_AvailableReplicasAlwaysAccurate(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	app := makeApp("myapp", "test-ns")
+	if err := r.Create(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	// First reconcile to create Deployment.
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var dep appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &dep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set replicas to 2.
+	dep.Status.AvailableReplicas = 2
+	if err := r.Status().Update(ctx, &dep); err != nil {
+		t.Fatal(err)
+	}
+
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var result iafv1alpha1.Application
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.AvailableReplicas != 2 {
+		t.Errorf("expected availableReplicas=2, got %d", result.Status.AvailableReplicas)
+	}
+}
+
+// TestReconcile_RunningToDeploying verifies that if replicas drop to 0 while
+// the app is Running, the controller transitions back to Deploying.
+func TestReconcile_RunningToDeploying(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	app := makeApp("myapp", "test-ns")
+	if err := r.Create(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reconcile and get the Deployment ready.
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var dep appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &dep); err != nil {
+		t.Fatal(err)
+	}
+	dep.Status.AvailableReplicas = 1
+	if err := r.Status().Update(ctx, &dep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reconcile to Running.
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var result iafv1alpha1.Application
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.Phase != iafv1alpha1.ApplicationPhaseRunning {
+		t.Fatalf("expected Running, got %q", result.Status.Phase)
+	}
+
+	// Re-fetch the Deployment to get the latest resourceVersion before updating status.
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &dep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate pods crashing (replicas drop to 0).
+	dep.Status.AvailableReplicas = 0
+	if err := r.Status().Update(ctx, &dep); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reconcile should regress to Deploying.
+	res := reconcileApp(t, r, "myapp", "test-ns")
+
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.Phase != iafv1alpha1.ApplicationPhaseDeploying {
+		t.Errorf("expected Deploying after replicas dropped to 0, got %q", result.Status.Phase)
+	}
+	if res.RequeueAfter != 10*time.Second {
+		t.Errorf("expected RequeueAfter=10s, got %v", res.RequeueAfter)
+	}
+}
+
+// TestReconcile_DeployingRequeues verifies that the controller requeues with
+// a 10s delay when in Deploying phase with no available replicas.
+func TestReconcile_DeployingRequeues(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	app := makeApp("myapp", "test-ns")
+	if err := r.Create(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	// First reconcile: Deploying with 0 available replicas.
+	res := reconcileApp(t, r, "myapp", "test-ns")
+
+	if res.RequeueAfter != 10*time.Second {
+		t.Errorf("expected RequeueAfter=10s while Deploying, got %v", res.RequeueAfter)
+	}
+}
+
+// TestReconcile_CreatesService verifies a Service is created alongside the Deployment.
+func TestReconcile_CreatesService(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	app := makeApp("myapp", "test-ns")
+	if err := r.Create(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var svc corev1.Service
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &svc); err != nil {
+		t.Fatalf("expected Service to be created: %v", err)
+	}
+	if len(svc.Spec.Ports) == 0 || svc.Spec.Ports[0].Port != 8080 {
+		t.Errorf("expected Service port 8080, got %v", svc.Spec.Ports)
+	}
+}
+
+// TestReconcile_URLSetDuringDeploying verifies the URL field is populated
+// during the Deploying phase, not just at Running.
+func TestReconcile_URLSetDuringDeploying(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	app := makeApp("myapp", "test-ns")
+	if err := r.Create(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	reconcileApp(t, r, "myapp", "test-ns")
+
+	var result iafv1alpha1.Application
+	if err := r.Get(ctx, types.NamespacedName{Name: "myapp", Namespace: "test-ns"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.URL == "" {
+		t.Error("expected URL to be set during Deploying phase")
+	}
+	expected := "http://myapp.example.com"
+	if result.Status.URL != expected {
+		t.Errorf("expected URL %q, got %q", expected, result.Status.URL)
+	}
+}
+
+// TestReconcile_NotFound is a sanity check that reconciling a deleted app
+// does not return an error.
+func TestReconcile_NotFound(t *testing.T) {
+	scheme := newTestScheme(t)
+	r := newReconciler(scheme)
+	ctx := context.Background()
+
+	result, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "gone", Namespace: "test-ns"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error for missing app, got %v", err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Errorf("expected empty result for missing app, got %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary

Creates the `internal/controller` package which was previously missing (causing `cmd/controller` to fail to build entirely).

**Phase lifecycle fixes (issues #10 + #11):**
- `setDeployingPhaseOnly`: sets `phase: Deploying` before creating/updating the Deployment — agents no longer see a jump from Building directly to Running
- `reconcileStatus`: called on every reconcile pass; reads `dep.Status.AvailableReplicas` and:
  - Sets `phase: Running` + `Ready=True` when `available >= 1`
  - Sets `phase: Deploying` + `RequeueAfter: 10s` when `available == 0`
  - Handles Running→Deploying regression (pod crashes, OOM kills)
- `availableReplicas` always written to Application status on every pass
- `url` populated during Deploying phase, not just Running

**Watches for event-driven reconciliation (issue #11):**
- `SetupWithManager` adds a `Watches()` call for kpack Image CRs using owner references, so build completion triggers immediate reconciliation instead of waiting for the 5s requeue timer
- `.Owns(&appsv1.Deployment{})` triggers reconciliation when Deployment `AvailableReplicas` changes

**Security:**
- Containers run as non-root (`runAsNonRoot: true`, `allowPrivilegeEscalation: false`)
- All owned resources (Deployment, Service) have `OwnerReferences` pointing to the Application

## Test plan
- [ ] `go test ./internal/controller/... -v` — all 7 tests pass
- [ ] `go test ./internal/... -v` — all packages green
- [ ] `go build ./cmd/controller/` succeeds (was previously broken)
- [ ] Phase lifecycle: Pending→Deploying→Running with correct timing
- [ ] Running→Deploying regression when replicas drop to 0

Closes #10
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)