### PR TITLE
Architecture: org coding standards, UI scaffolds, and GitHub workflow (#1, #3, #4)

### DIFF
--- a/docs/architecture/issue-1-org-coding-standards.md
+++ b/docs/architecture/issue-1-org-coding-standards.md
@@ -1,0 +1,102 @@
+# Architecture: Agent Coding Guidance — Org-Level Standards via MCP (Issue #1)
+
+## Technical Design
+
+### Approach
+
+Add an `iaf://org/coding-standards` MCP resource and a `coding-guide` MCP prompt. Standards are loaded from a YAML/JSON config file whose path is supplied via `IAF_ORG_STANDARDS_FILE`. A new `internal/orgstandards` package owns a `Loader` type: it reads the file on startup, serves the result through a goroutine-safe `Get()` method, and watches the file with `fsnotify` to hot-reload on change without a pod restart. If the env var is unset or the file does not exist, the loader returns compile-time platform defaults. `Dependencies` gains an `OrgStandards *orgstandards.Loader` field so both the resource and prompt read from the same live value. The `deploy-guide` prompt is updated to advertise the new resource URI and prompt name so agents can discover them.
+
+### Changes Required
+
+- **New `internal/orgstandards/loader.go`** — `OrgStandards` struct (all fields below), `Loader` type with `New(path string) *Loader`, `Start(ctx context.Context)` (starts fsnotify goroutine), `Stop()`, and `Get() *OrgStandards`; `Get` uses `sync.RWMutex` so readers never block writers; reload errors log and retain the previous value.
+- **New `internal/orgstandards/loader_test.go`** — table-driven tests: load from a valid temp file, load from a missing file (returns defaults), hot-reload (write new content to temp file, assert `Get()` returns updated value within a timeout).
+- **New `internal/mcp/resources/org_standards.go`** — `RegisterOrgStandards(server, deps)` registers `iaf://org/coding-standards` as a static MCP resource (not a template); handler calls `deps.OrgStandards.Get()`, marshals to JSON, returns `application/json`.
+- **New `internal/mcp/prompts/coding_guide.go`** — `RegisterCodingGuide(server, deps)` registers `coding-guide` prompt with optional `language` argument; handler calls `deps.OrgStandards.Get()`, merges per-language section with global standards, formats as Markdown; if `language` is unrecognised, returns global standards only without error.
+- **`internal/mcp/tools/deps.go`** — add `OrgStandards *orgstandards.Loader` field to `Dependencies`.
+- **`internal/mcp/server.go`** — call `RegisterOrgStandards` and `RegisterCodingGuide`; update `serverInstructions` constant to mention `coding-guide` prompt and `iaf://org/coding-standards`.
+- **`internal/mcp/prompts/deploy_guide.go`** — add a "Coding Standards" section that references `coding-guide` and `iaf://org/coding-standards`.
+- **`cmd/mcpserver/main.go`** — read `IAF_ORG_STANDARDS_FILE` from viper config (default `""`), create `orgstandards.New(path)`, call `loader.Start(ctx)`, pass to `deps`.
+- **`cmd/apiserver/main.go`** — same as mcpserver (future admin API may expose standards; wire it now).
+- **`internal/mcp/resources/resources_test.go`** — test `iaf://org/coding-standards` returns valid JSON with the expected top-level keys; test that `TestListResources` count is updated.
+- **`internal/mcp/prompts/prompts_test.go`** — tests: `coding-guide` without `language` returns global standards Markdown; with a valid `language` returns per-language notes merged in; with an unknown `language` returns global standards (no error).
+
+### Data / API Changes
+
+**New MCP resource**: `iaf://org/coding-standards`
+- Static (not a template), listed in `resources/list`
+- MIME type: `application/json`
+- Content structure:
+```json
+{
+  "healthCheckPath": "/health",
+  "loggingFormat": "json",
+  "defaultPort": 8080,
+  "envVarNaming": "UPPER_SNAKE_CASE",
+  "requiredEnvVars": [],
+  "bestPractices": [
+    "Listen on the PORT environment variable",
+    "Implement a health-check endpoint",
+    "Do not embed secrets in source code"
+  ],
+  "perLanguage": {
+    "go":     { "notes": [], "approvedLibraries": {} },
+    "nodejs": { "notes": [], "approvedLibraries": {} },
+    "python": { "notes": [], "approvedLibraries": {} },
+    "java":   { "notes": [], "approvedLibraries": {} },
+    "ruby":   { "notes": [], "approvedLibraries": {} }
+  }
+}
+```
+
+**New MCP prompt**: `coding-guide`, optional argument `language` (same aliases as `language-guide`).
+
+**New env var**: `IAF_ORG_STANDARDS_FILE` — absolute path to YAML or JSON file; empty = use platform defaults.
+
+**Config file format** (YAML preferred for operator readability; loader accepts both YAML and JSON by trying JSON unmarshal first):
+```yaml
+healthCheckPath: /health
+loggingFormat: json
+defaultPort: 8080
+envVarNaming: UPPER_SNAKE_CASE
+requiredEnvVars: []
+bestPractices:
+  - "Listen on the PORT environment variable"
+perLanguage:
+  go:
+    notes:
+      - "Use Go modules (go.mod); GOPATH mode is not supported"
+    approvedLibraries:
+      web: "net/http or github.com/labstack/echo"
+  nodejs:
+    notes:
+      - "Include package-lock.json for reproducible builds"
+```
+
+### Multi-tenancy & Shared Resource Impact
+
+The standards document is read-only and global — all sessions see the same value. No agent can write to it via MCP. The config file is loaded from a path set by the platform operator at pod startup; agents have no influence over the path or content. No shared K8s infrastructure is touched.
+
+### Security Considerations
+
+- **File path**: comes from env var set by the operator, not from agent input. No path traversal risk from agents. The loader should reject paths containing `..` as a defence-in-depth measure.
+- **File size limit**: parse only up to 1 MB; reject larger files with a startup error to prevent OOM from malicious YAML (billion-laughs, deeply nested anchors). Use `io.LimitReader` before unmarshaling.
+- **Hot-reload error safety**: if the file becomes unreadable or contains invalid YAML, the loader logs the error, retains the previous in-memory value, and does not crash. Fail-safe behaviour.
+- **No `needs-security-review`** — standards are read-only, no secrets, no external calls.
+
+### Resource & Performance Impact
+
+- One file read on startup + inotify kernel events only (no polling).
+- Zero additional K8s objects.
+- `Get()` is a mutex-protected in-memory read — effectively zero latency per prompt/resource call.
+- Binary size increase: negligible (no embedded files, just code).
+
+### Migration / Compatibility
+
+Purely additive. No existing tools, prompts, or resources are changed in a breaking way (deploy-guide text is extended, not modified). Existing deployments without `IAF_ORG_STANDARDS_FILE` receive platform defaults unchanged.
+
+### Open Questions for Developer
+
+1. **YAML library**: check `go.sum` for `gopkg.in/yaml.v3` — it is almost certainly a transitive dep via controller-runtime. If so, use it; otherwise use `encoding/json` only and require JSON format.
+2. **fsnotify dependency**: add `github.com/fsnotify/fsnotify` if not already present (check go.mod). It is the standard choice for file watching in Go. Viper already uses it internally.
+3. **Graceful shutdown**: `loader.Start(ctx)` should use the provided context for shutdown. When the context is cancelled (e.g., on SIGTERM), the watcher goroutine must exit cleanly without a leak.
+4. **Should apiserver expose the standards via REST?** Out of scope for this issue, but wiring the loader into the apiserver now makes it trivial to add a `GET /api/v1/org/standards` endpoint later.

--- a/docs/architecture/issue-3-ui-scaffold.md
+++ b/docs/architecture/issue-3-ui-scaffold.md
@@ -1,0 +1,110 @@
+# Architecture: Standard UI Scaffold Templates via MCP (Issue #3)
+
+## Technical Design
+
+### Approach
+
+Add an `iaf://scaffold/{framework}` MCP resource template and a `scaffold-guide` MCP prompt. All scaffold template files are embedded into the binary at compile time using Go's `//go:embed` directive, stored under `internal/mcp/resources/scaffolds/{framework}/`. The resource handler extracts the `{framework}` value from the URI, validates it against an allowlist (`nextjs`, `html`), and walks the embedded filesystem to build a `{"relative/path": "file_content"}` JSON map that agents can pass directly to `push_code`. The filesystem walk — not the URI value — determines which files are read, so there is no path traversal risk from agent-supplied input. The `scaffold-guide` prompt explains when to use the scaffold and how to extend it. Both `language-guide` (Node.js section) and `scaffold-guide` cross-reference each other.
+
+### Changes Required
+
+- **New `internal/mcp/resources/scaffolds/nextjs/`** — embedded Next.js scaffold files:
+  - `package.json` — Next.js 14 project; `start` script is `next start`; deps: `next`, `react`, `react-dom`, `tailwindcss`
+  - `pages/index.js` — minimal home page using layout component
+  - `pages/api/health.js` — Next.js API route returning `{ status: "ok" }` with HTTP 200
+  - `pages/_app.js` — wraps all pages with the layout and imports global CSS
+  - `styles/globals.css` — Tailwind base/components/utilities directives + org design tokens as CSS custom properties
+  - `tailwind.config.js` — colour palette, font family, spacing tokens; points to `pages/**` and `components/**` for PurgeCSS
+  - `postcss.config.js` — standard Tailwind postcss config
+  - `components/Layout.js` — navigation shell with org-branded header/footer
+  - `README.md` — explains how to add pages, extend design tokens, run locally
+
+- **New `internal/mcp/resources/scaffolds/html/`** — embedded plain-HTML + Tailwind via CDN scaffold:
+  - `package.json` — minimal; deps: `express`; `start` script is `node server.js`
+  - `server.js` — Express app: `express.static('public')` + explicit `GET /health` route returning 200 `{ status: "ok" }`; listens on `process.env.PORT || 8080`
+  - `public/index.html` — HTML5 page with Tailwind CDN `<script>` tag, navigation shell, main content area, org design tokens in `<style>` block as CSS custom properties
+  - `public/styles.css` — org design tokens for use alongside Tailwind CDN
+  - `README.md` — explains structure, how to add pages, how to migrate from CDN to build step
+
+- **New `internal/mcp/resources/scaffold.go`** — `RegisterScaffoldResource(server, deps)`:
+  - Uses `//go:embed scaffolds/**` on an `embed.FS` var
+  - Registers `iaf://scaffold/{framework}` as a `ResourceTemplate`
+  - Handler: extract framework from URI (`strings.TrimPrefix`), validate against `allowedFrameworks = []string{"nextjs","html"}`, then `fs.WalkDir(embedFS, "scaffolds/"+framework, ...)` to collect `{relative_path: content}` entries, marshal to JSON
+  - Returns `ResourceNotFoundError` for unknown frameworks
+  - Never passes the raw URI value to `embedFS.Open`; always constructs the path as `"scaffolds/" + allowlistedFramework + "/" + walkPath`
+
+- **New `internal/mcp/prompts/scaffold_guide.go`** — `RegisterScaffoldGuide(server, deps)`:
+  - Prompt `scaffold-guide` with optional `framework` argument (`nextjs`, `html`)
+  - Returns Markdown guide explaining: when to start from a scaffold vs from scratch, how to fetch the scaffold (read `iaf://scaffold/{framework}`), how to pass the file map to `push_code`, how to add pages, and how to stay within the design system
+  - If `framework` omitted, lists both frameworks
+
+- **`internal/mcp/resources/resources_test.go`** — new tests:
+  - `TestScaffoldResource_NextJS`: resource returns JSON, contains keys `package.json`, `pages/index.js`, `pages/api/health.js`, `styles/globals.css`
+  - `TestScaffoldResource_HTML`: resource returns JSON, contains keys `package.json`, `server.js`, `public/index.html`
+  - `TestScaffoldResource_Unknown`: `iaf://scaffold/react-native` returns error
+
+- **`internal/mcp/prompts/prompts_test.go`** — new tests:
+  - `TestScaffoldGuide_WithFramework`: prompt returns non-empty text containing framework name
+  - `TestScaffoldGuide_NoFramework`: prompt lists both frameworks
+
+- **`internal/mcp/server.go`** — call `RegisterScaffoldResource` and `RegisterScaffoldGuide`; update `serverInstructions` to mention scaffold resources
+
+- **`internal/mcp/prompts/language_guide.go`** — add note in Node.js `bestPractices` referencing `iaf://scaffold/nextjs` for frontend apps
+
+- **`internal/mcp/resources/resources_test.go`** — update `TestListResourceTemplates` count from 1 to 2 (adds `scaffold`)
+
+### Data / API Changes
+
+**New MCP resource template**: `iaf://scaffold/{framework}`
+- MIME type: `application/json`
+- Supported `{framework}` values: `nextjs`, `html`
+- Response shape:
+```json
+{
+  "package.json": "{\n  \"name\": \"myapp\", ...\n}",
+  "pages/index.js": "import Layout from '../components/Layout';\n...",
+  "pages/api/health.js": "export default function handler(req, res) { res.status(200).json({ status: 'ok' }); }",
+  "styles/globals.css": "@tailwind base;\n@tailwind components;\n...",
+  "tailwind.config.js": "module.exports = { content: [...], theme: { extend: { colors: {...} } } }",
+  "postcss.config.js": "module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } }",
+  "components/Layout.js": "...",
+  "README.md": "# IAF Next.js Scaffold\n..."
+}
+```
+
+**New MCP prompt**: `scaffold-guide`, optional argument `framework`.
+
+**No new env vars, no CRD changes, no new K8s objects.**
+
+### Multi-tenancy & Shared Resource Impact
+
+Scaffolds are static, embedded, and read-only. Every session sees the same scaffold content. No shared infrastructure is touched by reading a scaffold resource. No K8s objects are created until the agent calls `push_code` with the scaffold files.
+
+### Security Considerations
+
+- **Embedded content**: templates compiled into binary at build time; agents cannot inject or modify content. Template content **must be reviewed** before merge to ensure:
+  - No hardcoded secrets, API keys, or tokens
+  - No disabled CORS (`Access-Control-Allow-Origin: *` acceptable for a scaffold; `credentials: true` with wildcard is not)
+  - No `eval()`, `new Function()`, or equivalent dynamic code execution patterns
+  - No development-only configurations shipped as defaults (e.g., debug flags enabled)
+- **URI-to-path mapping**: the `{framework}` value extracted from the URI is compared against `allowedFrameworks` (a compile-time slice). The embed FS is then accessed using `"scaffolds/" + validatedFramework + "/"` — never the raw URI segment. This ensures no path traversal via `../` or encoded sequences.
+- **File size**: scaffold files are small (< 50 KB total per framework). No size limit needed for reads, but ensure CI review catches unusually large template additions.
+- **No `needs-security-review`** — beyond template content review in the PR itself.
+
+### Resource & Performance Impact
+
+- Binary size increase: ~50–100 KB for both scaffolds (all template files combined). Acceptable.
+- All reads are in-memory `embed.FS` lookups — effectively zero latency.
+- `fs.WalkDir` over the embedded subtree runs once per resource request; with ~10 files per scaffold this is microseconds.
+
+### Migration / Compatibility
+
+Purely additive. `TestListResources` count in the existing test must be updated from 2 static resources to 2 (static count unchanged) and `TestListResourceTemplates` from 1 to 2 templates. No existing API contracts change.
+
+### Open Questions for Developer
+
+1. **`//go:embed` and nested dirs**: `//go:embed scaffolds/**` does not recursively include hidden files (dot-files) or directories named with dots. If any scaffold file starts with `.` (e.g., `.eslintrc`), use `//go:embed all:scaffolds` instead. Verify this at implementation time.
+2. **`fs.WalkDir` path stripping**: `fs.WalkDir(embedFS, "scaffolds/nextjs", ...)` will produce paths like `scaffolds/nextjs/package.json`. Strip the `scaffolds/nextjs/` prefix when building the output map so the agent receives `package.json`, not `scaffolds/nextjs/package.json`.
+3. **Design token values**: use a neutral org color palette (e.g., Tailwind `slate` + a single brand accent in `blue-600`). Do not brand with any specific org identity in the default templates — operators can override by updating the template files.
+4. **Should the HTML scaffold use a CDN or a build step?** Decision: CDN only (no build step) for the `html` framework. The Next.js scaffold uses a full build step. This keeps the two scaffolds clearly differentiated by complexity.
+5. **`pages/api/health.js` content**: must return HTTP 200 even when no other pages load, so the Kubernetes readiness probe passes immediately after deployment. Use `res.status(200).json({ status: 'ok' })` — no database dependency in the health route.

--- a/docs/architecture/issue-4-github-workflow.md
+++ b/docs/architecture/issue-4-github-workflow.md
@@ -1,0 +1,174 @@
+# Architecture: GitHub Workflow Standard via MCP (Issue #4)
+
+## Technical Design
+
+### Approach
+
+Add three components: (1) an `iaf://org/github-standards` MCP resource returning a structured JSON document of org GitHub conventions, (2) a `github-guide` MCP prompt with an optional `workflow` argument, and (3) a `setup_github_repo` MCP tool that calls the GitHub REST API to create a repo, apply branch protection rules, and commit an embedded CI pipeline template. The GitHub API is abstracted behind a `github.Client` interface in a new `internal/github` package so tests can inject a mock. The platform's `IAF_GITHUB_TOKEN` is stored in `Dependencies` and never surfaced in tool output, logs, or error messages. All three components are registered only if `IAF_GITHUB_TOKEN` is non-empty; existing deployments without the env var see no new surface area. An `IAF_GITHUB_ORG` env var, when set, scopes all repo creation to that org; if unset, the tool fails fast with a clear error rather than creating repos in an agent's personal account.
+
+**Security note**: This design has moderate security risk. See Security Considerations. Adding `needs-security-review` label.
+
+### Changes Required
+
+- **New `internal/github/client.go`** — `Client` interface with methods: `CreateRepo(ctx, org, name, private bool) (*RepoInfo, error)`, `SetBranchProtection(ctx, owner, repo, branch string, cfg BranchProtectionConfig) error`, `CreateFile(ctx, owner, repo, path, message string, content []byte) error`; `RepoInfo` struct: `CloneURL`, `HTMLURL`, `Name`. `HTTPClient` concrete implementation using `net/http` with GitHub REST API v3; reads `Authorization: Bearer <token>` header from the token passed at construction.
+
+- **New `internal/github/mock_client.go`** — `MockClient` implementing `Client` interface for use in tests; configurable with per-method function fields (e.g., `CreateRepoFn func(...) (*RepoInfo, error)`).
+
+- **New `internal/github/client_test.go`** — unit tests for request construction and error handling using `httptest.NewServer`.
+
+- **New `internal/mcp/resources/github_standards.go`** — `RegisterGitHubStandards(server, deps)` registers `iaf://org/github-standards` as a static MCP resource; content built from a `GitHubStandards` struct defined in this file (org can override via the same org standards config file from issue #1 in a future iteration; for now hardcoded defaults).
+
+- **New `internal/mcp/prompts/github_guide.go`** — `RegisterGitHubGuide(server, deps)` registers `github-guide` prompt with optional `workflow` argument (`solo-agent`, `multi-agent`, `human-review`); returns a step-by-step Markdown playbook covering: create repo via `setup_github_repo`, clone, branch naming, commits, PRs, and IAF git-deployment integration.
+
+- **New `internal/mcp/tools/setup_github_repo.go`** — `RegisterSetupGithubRepo(server, deps)`:
+  - Input: `session_id string`, `repo_name string`, `visibility string` (`"private"` or `"public"`)
+  - Validates `session_id` via `deps.ResolveNamespace`
+  - Validates `repo_name` using `validation.ValidateGitHubRepoName` (see below)
+  - Validates `visibility` is `"private"` or `"public"`
+  - If `deps.GitHubOrg == ""`, returns error: `"IAF_GITHUB_ORG not configured; contact your platform operator"`
+  - Calls `deps.GitHub.CreateRepo(ctx, deps.GitHubOrg, repoName, private)`
+  - Calls `deps.GitHub.SetBranchProtection(ctx, owner, repoName, "main", protectionConfig)`
+  - Reads embedded CI template, calls `deps.GitHub.CreateFile(ctx, owner, repoName, ".github/workflows/ci.yml", "chore: add CI pipeline", ciTemplate)`
+  - Returns JSON: `{ "repo_name", "clone_url", "html_url", "visibility", "branch_protection_applied", "ci_workflow_committed" }`
+  - Wraps all GitHub errors before returning — strip any string that could contain the token
+
+- **New `internal/mcp/resources/scaffolds/github/ci.yml`** (embedded) — GitHub Actions CI pipeline template:
+  ```yaml
+  name: CI
+  on:
+    push:
+      branches: [main]
+    pull_request:
+  jobs:
+    ci:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - name: Set up environment
+          run: echo "Add language setup here (e.g., actions/setup-go, actions/setup-node)"
+        - name: Lint
+          run: echo "Add lint step here"
+        - name: Test
+          run: echo "Add test step here"
+        - name: Build
+          run: echo "Add build step here"
+  ```
+  The template passes CI (each step is `echo`-based) so branch protection checks do not block the initial push.
+
+- **`internal/validation/validation.go`** (from issue #14 design) — add `ValidateGitHubRepoName(name string) error`: max 100 characters, regexp `^[a-zA-Z0-9._-]+$`, rejects `..` traversal sequences; add test cases.
+
+- **`internal/mcp/tools/deps.go`** — add fields: `GitHubToken string`, `GitHubOrg string`, `GitHub github.Client` (interface type).
+
+- **`internal/mcp/server.go`** — after existing registrations, add a guarded block:
+  ```go
+  if deps.GitHub != nil {
+      tools.RegisterSetupGithubRepo(server, deps)
+      resources.RegisterGitHubStandards(server, deps)
+      prompts.RegisterGitHubGuide(server, deps)
+  }
+  ```
+  Update `serverInstructions` to mention `setup_github_repo` (shown only when GitHub is configured — acceptable to always include the description since the tool list controls availability).
+
+- **`internal/mcp/prompts/deploy_guide.go`** — add a "Git-Based Deployment with GitHub" section referencing `github-guide` prompt and `setup_github_repo` tool.
+
+- **`cmd/mcpserver/main.go`** — read `IAF_GITHUB_TOKEN` and `IAF_GITHUB_ORG` from viper config; if token non-empty, construct `github.NewHTTPClient(token)` and set `deps.GitHub`, `deps.GitHubToken`, `deps.GitHubOrg`.
+
+- **Tests**:
+  - `internal/mcp/tools/setup_github_repo_test.go` — table-driven: valid inputs succeed (mock returns canned RepoInfo); invalid `repo_name` returns validation error; missing `IAF_GITHUB_ORG` returns actionable error; GitHub API error (mock returns 422) returns descriptive error without exposing token.
+  - `internal/mcp/resources/resources_test.go` — test `iaf://org/github-standards` returns valid JSON with required keys.
+  - `internal/mcp/prompts/prompts_test.go` — test `github-guide` with each `workflow` value and without argument.
+
+### Data / API Changes
+
+**New MCP resource**: `iaf://org/github-standards`
+- Static (not a template), `application/json`
+- Structure:
+```json
+{
+  "defaultBranch": "main",
+  "branchNamingPattern": "^(feat|fix|chore|docs|test)/[a-z0-9][a-z0-9-]*$",
+  "requiredReviewers": {
+    "solo-agent": 0,
+    "multi-agent": 1,
+    "human-review": 1
+  },
+  "requiredStatusChecks": ["CI / ci"],
+  "commitMessageFormat": "Conventional Commits (https://www.conventionalcommits.org)",
+  "ciTemplate": ".github/workflows/ci.yml",
+  "iafIntegration": {
+    "deployBranch": "main",
+    "deployMethod": "git",
+    "note": "After repo setup, call deploy_app with git_url pointing to this repo"
+  }
+}
+```
+
+**New MCP prompt**: `github-guide`, optional argument `workflow` (`solo-agent` | `multi-agent` | `human-review`; default `solo-agent`).
+
+**New MCP tool**: `setup_github_repo`
+- Inputs: `session_id`, `repo_name`, `visibility`
+- Output:
+```json
+{
+  "repo_name": "myapp",
+  "clone_url": "https://github.com/myorg/myapp.git",
+  "html_url": "https://github.com/myorg/myapp",
+  "visibility": "private",
+  "branch_protection_applied": true,
+  "ci_workflow_committed": true
+}
+```
+
+**New env vars**: `IAF_GITHUB_TOKEN` (required for GitHub features), `IAF_GITHUB_ORG` (required at runtime; platform fails the tool call if unset).
+
+**New `github.Client` interface** in `internal/github` — not part of the public MCP API but a key internal contract.
+
+### Multi-tenancy & Shared Resource Impact
+
+GitHub is a shared resource outside Kubernetes. Any agent with a valid `session_id` can call `setup_github_repo`. There is no per-namespace quota on GitHub repo creation — a misconfigured or misbehaving agent could create many repos in the org.
+
+Mitigations:
+1. `IAF_GITHUB_ORG` restricts creation to a single org (operators must set this).
+2. `repo_name` validation prevents names that could conflict with platform repos or include path traversal.
+3. If `CreateRepo` returns a 422 (repo already exists), the tool returns an actionable error — it does NOT continue to set protection rules on a repo it did not create (could interfere with an existing project).
+4. Document the known limitation: no per-session repo quota. Operator-level GitHub org quotas (max repos, cost controls) are the backstop.
+
+The `iaf://org/github-standards` resource and `github-guide` prompt are read-only and global — no isolation concerns.
+
+### Security Considerations
+
+- **Token never exposed**: `IAF_GITHUB_TOKEN` must never appear in tool output, error messages, or log lines. All errors returned from `deps.GitHub.*` methods must be wrapped by the tool handler before returning to the agent. The `internal/github` client implementation must not include the token in error strings.
+- **Required token scopes**: `repo` (full control of private repositories, includes branch protection API). Do **not** use `admin:org` — it is not needed. Document the exact scope in deployment instructions.
+- **`IAF_GITHUB_ORG` enforcement**: if unset, `setup_github_repo` returns error `"IAF_GITHUB_ORG not configured; contact your platform operator"` immediately — it does not fall back to creating in the user account. This prevents agents from scattering repos across personal accounts when the operator forgets to set the env var.
+- **`repo_name` validation**: `ValidateGitHubRepoName` must reject: empty string, names containing `..`, names starting or ending with `.` or `-`, names longer than 100 characters. GitHub's own naming rules allow `.` and `_` — the validator must accept these while still applying the above restrictions. Never pass the raw `repo_name` to any shell command.
+- **CI template content**: the embedded `.github/workflows/ci.yml` must use only trusted actions (`actions/checkout@v4` pinned to SHA or major-version tag); must not include `${{ github.event.*.body }}` or any user-controlled input in `run:` steps without sanitization; must not `echo` secrets. Review the template before merge.
+- **Branch protection config**: for `solo-agent` workflow, set `required_status_checks` with `strict: true` and `contexts: ["CI / ci"]`; set `required_pull_request_reviews: null` (no PR review required). For `human-review`/`multi-agent`, set `required_pull_request_reviews: { required_approving_review_count: 1 }`. This prevents agents from self-approving PRs in review workflows.
+- **Rate limiting**: check GitHub API `X-RateLimit-Remaining` header; if ≤ 10, return error `"GitHub API rate limit nearly exhausted; try again later"` rather than proceeding (three API calls per tool invocation means running out mid-transaction could leave a repo in partially-configured state).
+- **Partial failure handling**: if `CreateRepo` succeeds but `SetBranchProtection` fails, the tool should return an error indicating partial success: `{ "repo_created": true, "clone_url": "...", "branch_protection_applied": false, "error": "branch protection failed: ..." }`. The agent can retry or report to the operator. Do not silently return success.
+
+**⚠ Escalate to security review (`needs-security-review`)**:
+- Token scope minimization and token rotation policy
+- Org allowlist enforcement (can `IAF_GITHUB_ORG` be bypassed?)
+- Risk of token compromise (token has `repo` scope — compromise affects all org repos)
+- CI template content review for supply chain risks (pinned actions, no user-controlled injection)
+
+### Resource & Performance Impact
+
+- 3 GitHub REST API calls per `setup_github_repo` invocation (create repo, set branch protection, create file).
+- GitHub rate limit for authenticated apps: 5,000 requests/hour. At typical agentic usage (<10 repos/hour), this is not a concern. Log `X-RateLimit-Remaining` at DEBUG level.
+- Binary size: +~1 KB for the embedded CI YAML template.
+- No additional K8s objects created by this feature.
+
+### Migration / Compatibility
+
+- Purely additive: the tool, resource, and prompt are registered only if `IAF_GITHUB_TOKEN != ""`. Existing deployments without the env var are unaffected.
+- No CRD changes, no API schema changes, no database migrations.
+- The `internal/github` package is a new internal dependency — no external import cycles.
+
+### Open Questions for Developer
+
+1. **HTTP client vs go-github library**: check `go.mod` for `github.com/google/go-github`. If absent, use `net/http` with manual JSON marshaling for the three required endpoints — this avoids adding a heavyweight dependency for three API calls. If `go-github` is already present (via some transitive dep), use it.
+2. **Partial failure response**: should the output struct include a `warnings` array for non-fatal issues (e.g., branch protection applied but CI file commit failed due to empty repo)? Recommend yes — agents need machine-actionable status for each step.
+3. **`multi-agent` workflow in `github-guide`**: describe the pattern as "Agent B fetches the PR URL from Agent A's output, calls the GitHub API to post a review comment via a separate MCP GitHub tool, and approves if all checks pass." This avoids requiring human intervention while maintaining a meaningful review gate.
+4. **IAF webhook auto-wiring**: should `setup_github_repo` also call the IAF API to register the repo URL for automatic re-deploys on push? Out of scope for this issue — leave as an open item in the `github-guide` prompt's "Next Steps" section.
+5. **Repo name collision**: if a repo with that name already exists in the org, return error `"repo 'myapp' already exists in org 'myorg'; choose a different name"` — do not attempt to configure the existing repo.


### PR DESCRIPTION
## Summary

Architecture review phase for three enhancement issues:

- **Issue #1** — Agent coding guidance: `iaf://org/coding-standards` resource + `coding-guide` prompt backed by a hot-reloadable config file (`IAF_ORG_STANDARDS_FILE`); new `internal/orgstandards` package with fsnotify file watcher
- **Issue #3** — Standard UI scaffolds: `iaf://scaffold/{framework}` resource template + `scaffold-guide` prompt; all templates embedded in binary via `go:embed`; initial frameworks: `nextjs` (Next.js 14 + Tailwind build) and `html` (Express static server + Tailwind CDN)
- **Issue #4** — GitHub workflow standard: `iaf://org/github-standards` resource + `github-guide` prompt + `setup_github_repo` tool; `internal/github.Client` interface for testable API calls; `IAF_GITHUB_TOKEN` / `IAF_GITHUB_ORG` env vars; issue #4 also tagged `needs-security-review`

## Changes in this PR

- `docs/architecture/issue-1-org-coding-standards.md`
- `docs/architecture/issue-3-ui-scaffold.md`
- `docs/architecture/issue-4-github-workflow.md`

Design comments posted on each issue. Labels updated to `status: needs-implementation`.

## Security escalations

Issue #4 (`setup_github_repo`) carries `needs-security-review` for:
- GitHub token scope minimization and rotation policy
- `IAF_GITHUB_ORG` allowlist enforcement
- `repo`-scoped token compromise blast radius
- CI pipeline template supply chain risk (action pinning)

## Test plan

- [ ] Design doc reviewed by PM/lead
- [ ] Security review complete for issue #4 before implementation begins
- [ ] Implementation PRs reference these docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)