### PR TITLE
Add git source authentication

### DIFF
--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -25,6 +25,8 @@ import (
 // +kubebuilder:rbac:groups=iaf.io,resources=applications/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;get;update;patch
 // +kubebuilder:rbac:groups=kpack.io,resources=images,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=traefik.io,resources=ingressroutes,verbs=get;list;watch;create;update;patch;delete
 

--- a/internal/k8s/git_credentials.go
+++ b/internal/k8s/git_credentials.go
@@ -1,0 +1,106 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// LabelCredentialType is set on every git credential Secret.
+	LabelCredentialType = "iaf.io/credential-type"
+
+	// AnnotationGitServer records the server URL on the Secret for informational purposes.
+	AnnotationGitServer = "iaf.io/git-server"
+
+	// AnnotationKpackGit is the annotation kpack uses to match a credential to a git URL.
+	AnnotationKpackGit = "kpack.io/git"
+
+	// KpackServiceAccount is the name of the kpack SA in each session namespace.
+	KpackServiceAccount = "iaf-kpack-sa"
+)
+
+// BuildGitCredentialSecret constructs a Kubernetes Secret for kpack git auth.
+// credType must be "basic-auth" or "ssh".
+// StringData is write-only; the API server converts it to base64 Data; credential
+// material is never read back by any IAF tool.
+func BuildGitCredentialSecret(namespace, name, credType, gitServerURL, username, password, privateKey string) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				LabelCredentialType: "git",
+			},
+			Annotations: map[string]string{
+				AnnotationKpackGit:  gitServerURL,
+				AnnotationGitServer: gitServerURL,
+			},
+		},
+	}
+
+	switch credType {
+	case "basic-auth":
+		secret.Type = corev1.SecretTypeBasicAuth
+		secret.StringData = map[string]string{
+			"username": username,
+			"password": password,
+		}
+	case "ssh":
+		secret.Type = corev1.SecretTypeSSHAuth
+		secret.StringData = map[string]string{
+			corev1.SSHAuthPrivateKey: privateKey,
+		}
+	}
+
+	return secret
+}
+
+// AddSecretToKpackSA appends secretName to the iaf-kpack-sa ServiceAccount's
+// secrets list (required by kpack for credential lookup). Idempotent.
+func AddSecretToKpackSA(ctx context.Context, c client.Client, namespace, secretName string) error {
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: KpackServiceAccount}, sa); err != nil {
+		return fmt.Errorf("getting kpack service account: %w", err)
+	}
+
+	for _, ref := range sa.Secrets {
+		if ref.Name == secretName {
+			return nil // already present
+		}
+	}
+
+	sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: secretName})
+	if err := c.Update(ctx, sa); err != nil {
+		return fmt.Errorf("updating kpack service account: %w", err)
+	}
+	return nil
+}
+
+// RemoveSecretFromKpackSA removes secretName from the iaf-kpack-sa ServiceAccount's
+// secrets list. Idempotent — if not present, it is a no-op.
+func RemoveSecretFromKpackSA(ctx context.Context, c client.Client, namespace, secretName string) error {
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: KpackServiceAccount}, sa); err != nil {
+		return fmt.Errorf("getting kpack service account: %w", err)
+	}
+
+	filtered := make([]corev1.ObjectReference, 0, len(sa.Secrets))
+	for _, ref := range sa.Secrets {
+		if ref.Name != secretName {
+			filtered = append(filtered, ref)
+		}
+	}
+	if len(filtered) == len(sa.Secrets) {
+		return nil // not present, no-op
+	}
+
+	sa.Secrets = filtered
+	if err := c.Update(ctx, sa); err != nil {
+		return fmt.Errorf("updating kpack service account: %w", err)
+	}
+	return nil
+}

--- a/internal/mcp/prompts/deploy_guide.go
+++ b/internal/mcp/prompts/deploy_guide.go
@@ -78,6 +78,15 @@ Before writing any code, read the org-level coding standards:
 - Prompt: ` + "`coding-guide`" + ` (accepts optional ` + "`language`" + ` argument) — markdown guide merging platform and org standards
 - Resource: ` + "`iaf://org/coding-standards`" + ` — machine-readable JSON standards document
 
+## Private Repository Access
+To clone a private git repository, you must first store a credential:
+1. Call ` + "`add_git_credential`" + ` with your session_id, a name, the type (` + "`basic-auth`" + ` or ` + "`ssh`" + `), and the git server URL.
+   - For ` + "`basic-auth`" + `: provide ` + "`git_server_url`" + ` as ` + "`https://github.com`" + ` (or your server), plus ` + "`username`" + ` and ` + "`password`" + ` (or a personal access token).
+   - For ` + "`ssh`" + `: provide ` + "`git_server_url`" + ` as ` + "`git@github.com`" + ` and ` + "`private_key`" + ` as your PEM-encoded SSH private key.
+2. Pass the credential name as ` + "`git_credential`" + ` when calling ` + "`deploy_app`" + `.
+3. To rotate a credential, call ` + "`delete_git_credential`" + ` then ` + "`add_git_credential`" + ` again.
+4. Credential material is never returned in any tool output — only name, type, and server URL are shown.
+
 ## Git-Based Deployment with GitHub
 When your code lives in a GitHub repository:
 - Call ` + "`setup_github_repo`" + ` to create the repo, apply branch protection, and commit a CI template.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -29,11 +29,14 @@ QUICK START:
 AVAILABLE TOOLS (all require session_id except register):
 - register: Get a session_id (CALL THIS FIRST)
 - push_code: Upload source code files to build and deploy (provide files as {"path": "content"} map)
-- deploy_app: Deploy from a container image or git repo
+- deploy_app: Deploy from a container image or git repo (use git_credential for private repos)
 - list_apps: See all your deployed apps
 - app_status: Check build/deploy progress for an app
 - app_logs: View application or build logs
 - delete_app: Remove an app and its resources
+- add_git_credential: Store a git credential (username/password or SSH key) for private repo access
+- list_git_credentials: List stored git credentials (no secrets returned)
+- delete_git_credential: Remove a git credential
 
 KEY DETAILS:
 - Apps are built automatically using Cloud Native Buildpacks (Go, Node.js, Python, Java, Ruby)
@@ -76,6 +79,9 @@ func NewServer(k8sClient client.Client, sessions *auth.SessionStore, store *sour
 	tools.RegisterRegisterTool(server, deps)
 	tools.RegisterDeployApp(server, deps)
 	tools.RegisterPushCode(server, deps)
+	tools.RegisterAddGitCredential(server, deps)
+	tools.RegisterListGitCredentials(server, deps)
+	tools.RegisterDeleteGitCredential(server, deps)
 	tools.RegisterAppStatus(server, deps)
 	if len(clientset) > 0 && clientset[0] != nil {
 		tools.RegisterAppLogsWithClientset(server, deps, clientset[0])

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -89,6 +89,9 @@ func TestNewServer_RegistersAllTools(t *testing.T) {
 		"app_logs",
 		"list_apps",
 		"delete_app",
+		"add_git_credential",
+		"list_git_credentials",
+		"delete_git_credential",
 	}
 
 	toolNames := map[string]bool{}

--- a/internal/mcp/tools/git_credentials.go
+++ b/internal/mcp/tools/git_credentials.go
@@ -1,0 +1,257 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	iafk8s "github.com/dlapiduz/iaf/internal/k8s"
+	"github.com/dlapiduz/iaf/internal/validation"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	maxCredentialsPerSession = 20
+	maxPasswordLen           = 4096
+	maxSSHKeyLen             = 16 * 1024
+)
+
+// AddGitCredentialInput is the input for the add_git_credential tool.
+type AddGitCredentialInput struct {
+	SessionID    string `json:"session_id"    jsonschema:"required - session ID from the register tool"`
+	Name         string `json:"name"          jsonschema:"required - credential name (DNS label: lowercase alphanumeric and hyphens)"`
+	Type         string `json:"type"          jsonschema:"required - credential type: 'basic-auth' or 'ssh'"`
+	GitServerURL string `json:"git_server_url" jsonschema:"required - server URL to associate credential with (https://... for basic-auth, git@<host> for ssh)"`
+	// basic-auth fields
+	Username string `json:"username,omitempty" jsonschema:"username (required for basic-auth)"`
+	Password string `json:"password,omitempty" jsonschema:"password or token (required for basic-auth, max 4096 bytes)"`
+	// ssh field
+	PrivateKey string `json:"private_key,omitempty" jsonschema:"PEM-encoded SSH private key (required for ssh, max 16 KB)"`
+}
+
+// ListGitCredentialsInput is the input for the list_git_credentials tool.
+type ListGitCredentialsInput struct {
+	SessionID string `json:"session_id" jsonschema:"required - session ID from the register tool"`
+}
+
+// DeleteGitCredentialInput is the input for the delete_git_credential tool.
+type DeleteGitCredentialInput struct {
+	SessionID string `json:"session_id" jsonschema:"required - session ID from the register tool"`
+	Name      string `json:"name"       jsonschema:"required - credential name to delete"`
+}
+
+// RegisterAddGitCredential registers the add_git_credential MCP tool.
+func RegisterAddGitCredential(server *gomcp.Server, deps *Dependencies) {
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "add_git_credential",
+		Description: "Store a git credential (username/password or SSH key) in the session namespace so kpack can clone private repositories. Requires session_id. Credential material is never returned in any tool output. To rotate a credential, delete it and re-create it.",
+	}, func(ctx context.Context, req *gomcp.CallToolRequest, input AddGitCredentialInput) (*gomcp.CallToolResult, any, error) {
+		namespace, err := deps.ResolveNamespace(input.SessionID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Validate name as DNS label.
+		if err := validation.ValidateAppName(input.Name); err != nil {
+			return nil, nil, fmt.Errorf("invalid credential name: %w", err)
+		}
+
+		// Validate type allowlist.
+		if input.Type != "basic-auth" && input.Type != "ssh" {
+			return nil, nil, fmt.Errorf("type must be 'basic-auth' or 'ssh'")
+		}
+
+		// Type-specific validation.
+		switch input.Type {
+		case "basic-auth":
+			if err := validation.ValidateBasicAuthGitServerURL(input.GitServerURL); err != nil {
+				return nil, nil, err
+			}
+			if input.Username == "" {
+				return nil, nil, fmt.Errorf("username is required for basic-auth")
+			}
+			if input.Password == "" {
+				return nil, nil, fmt.Errorf("password is required for basic-auth")
+			}
+			if len(input.Password) > maxPasswordLen {
+				return nil, nil, fmt.Errorf("password must be %d bytes or fewer", maxPasswordLen)
+			}
+		case "ssh":
+			if err := validation.ValidateSSHGitServerURL(input.GitServerURL); err != nil {
+				return nil, nil, err
+			}
+			if input.PrivateKey == "" {
+				return nil, nil, fmt.Errorf("private_key is required for ssh")
+			}
+			if len(input.PrivateKey) > maxSSHKeyLen {
+				return nil, nil, fmt.Errorf("private_key must be %d bytes or fewer", maxSSHKeyLen)
+			}
+			if !strings.HasPrefix(input.PrivateKey, "-----BEGIN ") {
+				return nil, nil, fmt.Errorf("private_key must be a PEM-encoded key (must start with '-----BEGIN ...')")
+			}
+		}
+
+		// Enforce per-session credential count limit.
+		var secretList corev1.SecretList
+		if err := deps.Client.List(ctx, &secretList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{iafk8s.LabelCredentialType: "git"},
+		); err != nil {
+			return nil, nil, fmt.Errorf("listing git credentials: %w", err)
+		}
+		if len(secretList.Items) >= maxCredentialsPerSession {
+			return nil, nil, fmt.Errorf("credential limit reached: a session may have at most %d git credentials; delete an existing one before adding a new one", maxCredentialsPerSession)
+		}
+
+		// Build and create the Secret.
+		secret := iafk8s.BuildGitCredentialSecret(
+			namespace, input.Name, input.Type, input.GitServerURL,
+			input.Username, input.Password, input.PrivateKey,
+		)
+		if err := deps.Client.Create(ctx, secret); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil, nil, fmt.Errorf("credential %q already exists; delete it first to replace it", input.Name)
+			}
+			return nil, nil, fmt.Errorf("creating credential: %w", err)
+		}
+
+		// Patch the kpack SA. On failure, clean up the Secret before returning.
+		if err := iafk8s.AddSecretToKpackSA(ctx, deps.Client, namespace, input.Name); err != nil {
+			// Best-effort cleanup.
+			_ = deps.Client.Delete(ctx, secret)
+			return nil, nil, fmt.Errorf("registering credential with kpack service account: %w", err)
+		}
+
+		result := map[string]any{
+			"name":           input.Name,
+			"type":           input.Type,
+			"git_server_url": input.GitServerURL,
+			"created":        true,
+		}
+		text, _ := json.MarshalIndent(result, "", "  ")
+		return &gomcp.CallToolResult{
+			Content: []gomcp.Content{&gomcp.TextContent{Text: string(text)}},
+		}, nil, nil
+	})
+}
+
+// RegisterListGitCredentials registers the list_git_credentials MCP tool.
+func RegisterListGitCredentials(server *gomcp.Server, deps *Dependencies) {
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "list_git_credentials",
+		Description: "List all git credentials stored in the current session. Returns name, type, and server URL — never credential material.",
+	}, func(ctx context.Context, req *gomcp.CallToolRequest, input ListGitCredentialsInput) (*gomcp.CallToolResult, any, error) {
+		namespace, err := deps.ResolveNamespace(input.SessionID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var secretList corev1.SecretList
+		if err := deps.Client.List(ctx, &secretList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{iafk8s.LabelCredentialType: "git"},
+		); err != nil {
+			return nil, nil, fmt.Errorf("listing git credentials: %w", err)
+		}
+
+		type credInfo struct {
+			Name         string `json:"name"`
+			Type         string `json:"type"`
+			GitServerURL string `json:"git_server_url"`
+			CreatedAt    string `json:"created_at"`
+		}
+		creds := make([]credInfo, 0, len(secretList.Items))
+		for _, s := range secretList.Items {
+			credType := credTypeFromSecretType(s.Type)
+			serverURL := s.Annotations[iafk8s.AnnotationGitServer]
+			var createdAt string
+			if !s.CreationTimestamp.IsZero() {
+				createdAt = s.CreationTimestamp.UTC().Format(time.RFC3339)
+			}
+			creds = append(creds, credInfo{
+				Name:         s.Name,
+				Type:         credType,
+				GitServerURL: serverURL,
+				CreatedAt:    createdAt,
+			})
+		}
+
+		result := map[string]any{
+			"credentials": creds,
+			"total":       len(creds),
+		}
+		text, _ := json.MarshalIndent(result, "", "  ")
+		return &gomcp.CallToolResult{
+			Content: []gomcp.Content{&gomcp.TextContent{Text: string(text)}},
+		}, nil, nil
+	})
+}
+
+// RegisterDeleteGitCredential registers the delete_git_credential MCP tool.
+func RegisterDeleteGitCredential(server *gomcp.Server, deps *Dependencies) {
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "delete_git_credential",
+		Description: "Delete a git credential from the current session. Also removes it from the kpack service account so it will no longer be used for builds.",
+	}, func(ctx context.Context, req *gomcp.CallToolRequest, input DeleteGitCredentialInput) (*gomcp.CallToolResult, any, error) {
+		namespace, err := deps.ResolveNamespace(input.SessionID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if input.Name == "" {
+			return nil, nil, fmt.Errorf("name is required")
+		}
+
+		// Fetch the Secret and verify it is a git credential (label guard).
+		secret := &corev1.Secret{}
+		if err := deps.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: input.Name}, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil, fmt.Errorf("credential %q not found", input.Name)
+			}
+			return nil, nil, fmt.Errorf("getting credential: %w", err)
+		}
+		if secret.Labels[iafk8s.LabelCredentialType] != "git" {
+			return nil, nil, fmt.Errorf("secret %q is not a git credential managed by IAF", input.Name)
+		}
+
+		// Remove from kpack SA before deleting the Secret.
+		if err := iafk8s.RemoveSecretFromKpackSA(ctx, deps.Client, namespace, input.Name); err != nil {
+			return nil, nil, fmt.Errorf("removing credential from kpack service account: %w", err)
+		}
+
+		if err := deps.Client.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: input.Name, Namespace: namespace},
+		}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil, fmt.Errorf("credential %q not found", input.Name)
+			}
+			return nil, nil, fmt.Errorf("deleting credential: %w", err)
+		}
+
+		result := map[string]any{
+			"name":    input.Name,
+			"deleted": true,
+		}
+		text, _ := json.MarshalIndent(result, "", "  ")
+		return &gomcp.CallToolResult{
+			Content: []gomcp.Content{&gomcp.TextContent{Text: string(text)}},
+		}, nil, nil
+	})
+}
+
+// credTypeFromSecretType converts a Kubernetes secret type to the IAF credential type string.
+func credTypeFromSecretType(t corev1.SecretType) string {
+	switch t {
+	case corev1.SecretTypeBasicAuth:
+		return "basic-auth"
+	case corev1.SecretTypeSSHAuth:
+		return "ssh"
+	default:
+		return string(t)
+	}
+}

--- a/internal/mcp/tools/git_credentials_test.go
+++ b/internal/mcp/tools/git_credentials_test.go
@@ -1,0 +1,571 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iafv1alpha1 "github.com/dlapiduz/iaf/api/v1alpha1"
+	"github.com/dlapiduz/iaf/internal/auth"
+	iafk8s "github.com/dlapiduz/iaf/internal/k8s"
+	"github.com/dlapiduz/iaf/internal/mcp/tools"
+	"github.com/dlapiduz/iaf/internal/sourcestore"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// setupCredToolServer creates a server with the three git credential tools registered
+// and returns the client session, session store, and the underlying k8s client for assertions.
+func setupCredToolServer(t *testing.T) (*gomcp.ClientSession, *auth.SessionStore, client.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	_ = iafv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	store, err := sourcestore.New(t.TempDir(), "http://localhost:8080", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := auth.NewSessionStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &tools.Dependencies{
+		Client:     k8sClient,
+		Store:      store,
+		BaseDomain: "test.example.com",
+		Sessions:   sessions,
+	}
+
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	tools.RegisterRegisterTool(server, deps)
+	tools.RegisterAddGitCredential(server, deps)
+	tools.RegisterListGitCredentials(server, deps)
+	tools.RegisterDeleteGitCredential(server, deps)
+	tools.RegisterDeployApp(server, deps)
+
+	st, ct := gomcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatal(err)
+	}
+	mc := gomcp.NewClient(&gomcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	cs, err := mc.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	return cs, sessions, k8sClient
+}
+
+// registerCredSession registers a session (which also creates the kpack SA via EnsureNamespace)
+// and returns the session ID and namespace.
+func registerCredSession(t *testing.T, cs *gomcp.ClientSession, k8sClient client.Client) (sessionID, namespace string) {
+	t.Helper()
+	ctx := context.Background()
+	_ = k8sClient // retained in signature for use in test assertions
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "register",
+		Arguments: map[string]any{"name": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	json.Unmarshal([]byte(res.Content[0].(*gomcp.TextContent).Text), &out)
+	sessionID = out["session_id"].(string)
+	namespace = out["namespace"].(string)
+	return sessionID, namespace
+}
+
+func TestAddGitCredential_BasicAuth(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "github-creds",
+			"type":           "basic-auth",
+			"git_server_url": "https://github.com",
+			"username":       "myuser",
+			"password":       "ghp_token",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*gomcp.TextContent).Text)
+	}
+
+	var out map[string]any
+	json.Unmarshal([]byte(res.Content[0].(*gomcp.TextContent).Text), &out)
+
+	// Output must not contain credential material.
+	text := res.Content[0].(*gomcp.TextContent).Text
+	if strings.Contains(text, "ghp_token") {
+		t.Error("password must not appear in tool output")
+	}
+	if strings.Contains(text, "myuser") {
+		t.Error("username must not appear in tool output")
+	}
+	if out["created"] != true {
+		t.Errorf("expected created=true, got %v", out["created"])
+	}
+	if out["git_server_url"] != "https://github.com" {
+		t.Errorf("expected git_server_url in output, got %v", out["git_server_url"])
+	}
+
+	// Secret must exist with correct type and labels.
+	secret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "github-creds"}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if secret.Type != corev1.SecretTypeBasicAuth {
+		t.Errorf("expected type kubernetes.io/basic-auth, got %s", secret.Type)
+	}
+	if secret.Labels[iafk8s.LabelCredentialType] != "git" {
+		t.Errorf("expected label %s=git", iafk8s.LabelCredentialType)
+	}
+	if secret.Annotations[iafk8s.AnnotationKpackGit] != "https://github.com" {
+		t.Errorf("expected kpack.io/git annotation")
+	}
+
+	// kpack SA must have the secret in its secrets list.
+	sa := &corev1.ServiceAccount{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: iafk8s.KpackServiceAccount}, sa); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, ref := range sa.Secrets {
+		if ref.Name == "github-creds" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected secret to be added to kpack SA secrets list")
+	}
+}
+
+func TestAddGitCredential_SSH(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	fakeKey := "-----BEGIN OPENSSH PRIVATE KEY-----\nZmFrZWtleQ==\n-----END OPENSSH PRIVATE KEY-----\n"
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "ssh-creds",
+			"type":           "ssh",
+			"git_server_url": "git@github.com",
+			"private_key":    fakeKey,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*gomcp.TextContent).Text)
+	}
+
+	text := res.Content[0].(*gomcp.TextContent).Text
+	if strings.Contains(text, fakeKey) || strings.Contains(text, "PRIVATE KEY") {
+		t.Error("private key must not appear in tool output")
+	}
+
+	secret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "ssh-creds"}, secret); err != nil {
+		t.Fatalf("expected secret to exist: %v", err)
+	}
+	if secret.Type != corev1.SecretTypeSSHAuth {
+		t.Errorf("expected type kubernetes.io/ssh-auth, got %s", secret.Type)
+	}
+}
+
+func TestAddGitCredential_InvalidURL_HTTP(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, _ := registerCredSession(t, cs, k8sClient)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "bad-creds",
+			"type":           "basic-auth",
+			"git_server_url": "http://github.com",
+			"username":       "user",
+			"password":       "pass",
+		},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error for http:// scheme")
+	}
+}
+
+func TestAddGitCredential_InvalidURL_InternalIP(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, _ := registerCredSession(t, cs, k8sClient)
+
+	for _, url := range []string{
+		"https://10.0.0.1",
+		"https://192.168.1.1",
+		"https://127.0.0.1",
+		"https://169.254.169.254",
+	} {
+		t.Run(url, func(t *testing.T) {
+			res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+				Name: "add_git_credential",
+				Arguments: map[string]any{
+					"session_id":     sid,
+					"name":           "bad-creds",
+					"type":           "basic-auth",
+					"git_server_url": url,
+					"username":       "user",
+					"password":       "pass",
+				},
+			})
+			if err == nil && (res == nil || !res.IsError) {
+				t.Errorf("expected error for internal IP URL %q", url)
+			}
+		})
+	}
+}
+
+func TestAddGitCredential_InvalidType(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, _ := registerCredSession(t, cs, k8sClient)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "bad-creds",
+			"type":           "bearer",
+			"git_server_url": "https://github.com",
+			"username":       "user",
+			"password":       "pass",
+		},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error for invalid type")
+	}
+}
+
+func TestAddGitCredential_SSH_InvalidKey(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, _ := registerCredSession(t, cs, k8sClient)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "bad-creds",
+			"type":           "ssh",
+			"git_server_url": "git@github.com",
+			"private_key":    "not-a-pem-key",
+		},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error for non-PEM SSH key")
+	}
+}
+
+func TestAddGitCredential_CountLimit(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	// Directly create 20 fake git credential secrets to hit the limit.
+	for i := 0; i < 20; i++ {
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("cred-%02d", i),
+				Namespace: namespace,
+				Labels:    map[string]string{iafk8s.LabelCredentialType: "git"},
+			},
+			Type: corev1.SecretTypeBasicAuth,
+		}
+		if err := k8sClient.Create(ctx, s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "one-too-many",
+			"type":           "basic-auth",
+			"git_server_url": "https://github.com",
+			"username":       "user",
+			"password":       "pass",
+		},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error when exceeding credential limit")
+	}
+	errText := res.Content[0].(*gomcp.TextContent).Text
+	if !strings.Contains(errText, "limit") {
+		t.Errorf("expected 'limit' in error message, got: %s", errText)
+	}
+}
+
+func TestListGitCredentials_NoCredentialMaterial(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	// Add a credential first.
+	_, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "my-creds",
+			"type":           "basic-auth",
+			"git_server_url": "https://github.com",
+			"username":       "secretuser",
+			"password":       "secretpass",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = namespace
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "list_git_credentials",
+		Arguments: map[string]any{"session_id": sid},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*gomcp.TextContent).Text)
+	}
+
+	text := res.Content[0].(*gomcp.TextContent).Text
+
+	// Credential material must not appear in the listing.
+	if strings.Contains(text, "secretuser") {
+		t.Error("username must not appear in list output")
+	}
+	if strings.Contains(text, "secretpass") {
+		t.Error("password must not appear in list output")
+	}
+	if strings.Contains(text, "stringData") || strings.Contains(text, "data") {
+		t.Error("raw secret data must not appear in list output")
+	}
+
+	var out map[string]any
+	json.Unmarshal([]byte(text), &out)
+	if out["total"].(float64) != 1 {
+		t.Errorf("expected 1 credential, got %v", out["total"])
+	}
+	creds := out["credentials"].([]any)
+	cred := creds[0].(map[string]any)
+	if cred["name"] != "my-creds" {
+		t.Errorf("expected name 'my-creds', got %v", cred["name"])
+	}
+	if cred["type"] != "basic-auth" {
+		t.Errorf("expected type 'basic-auth', got %v", cred["type"])
+	}
+	if cred["git_server_url"] != "https://github.com" {
+		t.Errorf("expected git_server_url 'https://github.com', got %v", cred["git_server_url"])
+	}
+}
+
+func TestDeleteGitCredential_Success(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	// Add a credential.
+	_, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "my-creds",
+			"type":           "basic-auth",
+			"git_server_url": "https://github.com",
+			"username":       "user",
+			"password":       "pass",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "delete_git_credential",
+		Arguments: map[string]any{"session_id": sid, "name": "my-creds"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*gomcp.TextContent).Text)
+	}
+
+	// Secret must be gone.
+	secret := &corev1.Secret{}
+	err = k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "my-creds"}, secret)
+	if err == nil {
+		t.Error("expected secret to be deleted")
+	}
+
+	// SA secrets list must no longer contain the credential.
+	sa := &corev1.ServiceAccount{}
+	k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: iafk8s.KpackServiceAccount}, sa)
+	for _, ref := range sa.Secrets {
+		if ref.Name == "my-creds" {
+			t.Error("expected secret to be removed from kpack SA secrets list")
+		}
+	}
+}
+
+func TestDeleteGitCredential_LabelCheck(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	// Create a secret WITHOUT the git credential label (simulates an arbitrary secret).
+	arbitrary := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "not-a-credential",
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	if err := k8sClient.Create(ctx, arbitrary); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "delete_git_credential",
+		Arguments: map[string]any{"session_id": sid, "name": "not-a-credential"},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error when trying to delete a non-credential secret")
+	}
+}
+
+func TestDeleteGitCredential_NotFound(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, _ := registerCredSession(t, cs, k8sClient)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "delete_git_credential",
+		Arguments: map[string]any{"session_id": sid, "name": "nonexistent"},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error for nonexistent credential")
+	}
+}
+
+func TestDeployApp_WithGitCredential(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	// Add a credential.
+	_, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "add_git_credential",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "my-creds",
+			"type":           "basic-auth",
+			"git_server_url": "https://github.com",
+			"username":       "user",
+			"password":       "pass",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = namespace
+
+	// Deploy with the credential — should succeed.
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "deploy_app",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "my-app",
+			"git_url":        "https://github.com/example/repo",
+			"git_credential": "my-creds",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("deploy_app with valid credential failed: %s", res.Content[0].(*gomcp.TextContent).Text)
+	}
+}
+
+func TestDeployApp_WithNonexistentGitCredential(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, _ := registerCredSession(t, cs, k8sClient)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "deploy_app",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "my-app",
+			"git_url":        "https://github.com/example/repo",
+			"git_credential": "nonexistent",
+		},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error when git_credential does not exist")
+	}
+}
+
+func TestDeployApp_WithArbitrarySecretAsCredential(t *testing.T) {
+	cs, _, k8sClient := setupCredToolServer(t)
+	ctx := context.Background()
+	sid, namespace := registerCredSession(t, cs, k8sClient)
+
+	// Create a secret without the git credential label.
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: namespace},
+		Type:       corev1.SecretTypeOpaque,
+	}
+	k8sClient.Create(ctx, s)
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "deploy_app",
+		Arguments: map[string]any{
+			"session_id":     sid,
+			"name":           "my-app",
+			"git_url":        "https://github.com/example/repo",
+			"git_credential": "other-secret",
+		},
+	})
+	if err == nil && (res == nil || !res.IsError) {
+		t.Fatal("expected error when using a non-credential secret as git_credential")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `add_git_credential`, `list_git_credentials`, and `delete_git_credential` MCP tools for managing kpack git credentials in session namespaces
- Adds optional `git_credential` parameter to `deploy_app` with label-guard validation
- Adds URL validation functions to the validation package (SSRF prevention via RFC 1918 / loopback rejection)
- Adds RBAC markers for Secrets and ServiceAccount update/patch to the controller
- Documents the private repository access workflow in the deploy-guide prompt

## Security controls implemented

- basic-auth: `https://` scheme required; RFC 1918, loopback, and link-local IPs rejected
- SSH: `git@<host>` pattern only; same internal-IP block
- SSH keys: PEM format check (`-----BEGIN ...`), ≤ 16 KB
- Passwords: ≤ 4096 bytes
- 20 credentials per session limit
- Credential material never surfaces in any tool output
- `delete_git_credential` verifies `iaf.io/credential-type=git` label before deleting any Secret
- `deploy_app` validates the named credential exists and carries the label before creating the Application CR

## Test plan

- [x] `TestAddGitCredential_BasicAuth` — Secret created, SA patched, no credential material in output
- [x] `TestAddGitCredential_SSH` — `kubernetes.io/ssh-auth` type, `ssh-privatekey` key
- [x] `TestAddGitCredential_InvalidURL_HTTP` — rejects `http://` scheme
- [x] `TestAddGitCredential_InvalidURL_InternalIP` — rejects 10.x, 192.168.x, 127.x, 169.254.x
- [x] `TestAddGitCredential_InvalidType` — rejects unknown type
- [x] `TestAddGitCredential_SSH_InvalidKey` — rejects non-PEM key
- [x] `TestAddGitCredential_CountLimit` — 21st credential rejected
- [x] `TestListGitCredentials_NoCredentialMaterial` — no username/password/stringData/data in output
- [x] `TestDeleteGitCredential_Success` — Secret deleted, removed from SA secrets list
- [x] `TestDeleteGitCredential_LabelCheck` — cannot delete unlabelled secret
- [x] `TestDeleteGitCredential_NotFound` — 404 handled correctly
- [x] `TestDeployApp_WithGitCredential` — deploy succeeds with valid credential
- [x] `TestDeployApp_WithNonexistentGitCredential` — error returned
- [x] `TestDeployApp_WithArbitrarySecretAsCredential` — label guard enforced
- [x] `make test` — all 70+ tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)