### PR TITLE
Architecture: issues #15 and #16 (logs multi-replica, test coverage)

### DIFF
--- a/docs/architecture/issue-15-app-logs-multi-replica.md
+++ b/docs/architecture/issue-15-app-logs-multi-replica.md
@@ -1,0 +1,128 @@
+# Architecture: app_logs Multi-Replica Support and Consistent Pod Selection (Issue #15)
+
+## Technical Design
+
+### Approach
+
+Fix pod selection in both the MCP tool (`RegisterAppLogsWithClientset`) and the REST API handler (`handlers/logs.go`) to consistently use the **most recently started pod** (sort by `CreationTimestamp` descending). Add an optional `pod_name` parameter that, when provided, fetches logs from a specific pod after validating it belongs to the app via label selector (preventing cross-app log access). Return `availablePods` in the response so agents can make targeted follow-up calls. Both the MCP tool and REST API handler are updated together since they share the same bug pattern.
+
+### Changes Required
+
+**`internal/mcp/tools/logs.go`**:
+
+1. Update `AppLogsInput`:
+   ```go
+   type AppLogsInput struct {
+       SessionID string `json:"session_id" ...`
+       Name      string `json:"name" ...`
+       Lines     int64  `json:"lines,omitempty" ...`
+       BuildLogs bool   `json:"build_logs,omitempty" ...`
+       PodName   string `json:"pod_name,omitempty" jsonschema:"optional - specific pod name to get logs from; if omitted, uses most recently started pod"`
+   }
+   ```
+
+2. Add helper `selectPod(pods []corev1.Pod, podName string, labelKey string) (*corev1.Pod, []string, error)`:
+   - `allPodNames`: collects all pod names from the pod list (capped at 10 — see open questions)
+   - If `podName` is provided:
+     - Scan the pod list for a pod with `Name == podName` **and** the expected label (`labelKey: appName`) present — validates the pod belongs to this app; if not found, return `fmt.Errorf("pod %q not found for application %q", podName, appName)`
+   - If `podName` is not provided:
+     - Sort pods by `CreationTimestamp` descending (`sort.Slice` on `pod.CreationTimestamp.Time`)
+     - Return `pods[0]`
+
+3. In `RegisterAppLogsWithClientset` handler:
+   - Replace `pod := podList.Items[len(podList.Items)-1]` with call to `selectPod`
+   - Pass `labelKey` and `input.Name` for the namespace isolation check
+   - Add `availablePods` to result map: list of pod names (all pods matching the selector, capped at 10)
+   - Build logs path already uses last item — change to use `selectPod` with sort-by-creation-desc (same behaviour, now consistent and documented)
+
+4. Update `RegisterAppLogs` (degraded, no clientset):
+   - Add `PodName` to input struct (accepted but ignored)
+   - Response message can mention `pod_name` is not supported without a clientset
+
+**`internal/api/handlers/logs.go`**:
+
+1. `GetLogs` — replace `pod := podList.Items[0]` with most-recently-started-pod selection:
+   ```go
+   // Sort descending by creation timestamp
+   sort.Slice(podList.Items, func(i, j int) bool {
+       return podList.Items[i].CreationTimestamp.After(podList.Items[j].CreationTimestamp.Time)
+   })
+   pod := podList.Items[0]
+   ```
+   - Add `pod_name` query parameter: `podName := c.QueryParam("pod_name")`
+   - If `podName != ""`, validate it belongs to the app using the same label check as the MCP tool
+   - Return `availablePods` in response: `[]string{pod.Name, ...}` (all pod names, capped at 10)
+
+2. `GetBuildLogs` — already uses `Items[len-1]`. Change to sort-by-creation-desc for consistency. Document this in comments.
+
+**New `internal/k8s/pods.go`** (extract shared logic):
+- `SelectMostRecentPod(pods []corev1.Pod) *corev1.Pod` — sort + return first
+- `PodNames(pods []corev1.Pod, limit int) []string` — collect names up to limit
+- `FindPodByName(pods []corev1.Pod, name, labelKey, labelValue string) (*corev1.Pod, error)` — scan + validate label
+
+This avoids duplicating the same selection logic between the MCP tool and REST handler.
+
+**Updated test file `internal/mcp/tools/logs_test.go`** (new or updated):
+- `TestAppLogs_SinglePod`: existing behaviour unchanged
+- `TestAppLogs_MultiPod_DefaultSelection`: returns most recently started pod (verify via `podName` in response)
+- `TestAppLogs_MultiPod_SpecificPod`: `pod_name` returns that pod's logs
+- `TestAppLogs_InvalidPodName`: pod not in app's label set → error
+- `TestAppLogs_AvailablePods`: response includes `availablePods` list
+
+**Updated test file `internal/api/handlers/logs_test.go`** (new):
+- Same scenarios as MCP tool tests but via HTTP
+
+### Data / API Changes
+
+**`AppLogsInput`** — new optional field `pod_name`.
+
+**MCP tool response** — new fields:
+```json
+{
+  "name": "myapp",
+  "logs": "...",
+  "podName": "myapp-7d9b4c-xkqj2",
+  "availablePods": ["myapp-7d9b4c-xkqj2", "myapp-7d9b4c-bpfq8"],
+  "phase": "Running"
+}
+```
+
+**REST API response** (`GET /api/v1/applications/:name/logs`):
+```json
+{
+  "logs": "...",
+  "pods": 2,
+  "podName": "myapp-7d9b4c-xkqj2",
+  "availablePods": ["myapp-7d9b4c-xkqj2", "myapp-7d9b4c-bpfq8"]
+}
+```
+
+### Multi-tenancy & Shared Resource Impact
+
+The `pod_name` validation (label check) is the critical isolation control:
+- Agent requests logs from `pod_name: "other-agent-pod-xyz"` → not found in this app's pod list → returns error. No cross-app or cross-namespace log access.
+- The validation must use `client.InNamespace(namespace)` + `client.MatchingLabels` — never skip the namespace filter.
+
+### Security Considerations
+
+- **`pod_name` injection**: validate against the pod list derived from the app's label selector, not via a direct `clientset.CoreV1().Pods(namespace).GetLogs(podName, ...)` call without validation. The validation step is mandatory.
+- **Log content**: log content is user-app-generated; it may contain sensitive data. The platform does not filter log content — that is the agent/operator's responsibility. Document this in the prompt.
+- No new RBAC changes needed (existing `pods/log get` permission covers any pod in the namespace).
+
+### Resource & Performance Impact
+
+- `sort.Slice` on O(replicas) pods: negligible.
+- `availablePods` adds a small JSON field. Cap at 10 to bound response size.
+
+### Migration / Compatibility
+
+- `pod_name` is optional — existing callers unaffected.
+- Pod selection change (from `Items[0]` → most-recent) is a **behaviour change**. For single-replica apps, behaviour is identical (one pod). For multi-replica apps, the returned pod may differ from before. This is the intended fix.
+- No CRD changes, no env var changes.
+
+### Open Questions for Developer
+
+1. **`availablePods` cap**: 10 seems reasonable. Should it be configurable? No — hardcode 10 for simplicity.
+2. **`availablePods` always vs on-demand**: issue asks whether to always return it or only when `pod_name` is not specified. Decision: always return it. It's a small field and always useful for agents debugging multi-replica apps.
+3. **`sort` import**: add `"sort"` to imports in both files.
+4. **`SelectMostRecentPod` edge case**: if all pods have the same `CreationTimestamp`, order is stable (sort preserves relative order for equal elements in Go's `sort.Slice` is not stable — use `sort.SliceStable`).

--- a/docs/architecture/issue-16-test-coverage.md
+++ b/docs/architecture/issue-16-test-coverage.md
@@ -1,0 +1,118 @@
+# Architecture: Test Coverage for Controller and REST API Handlers (Issue #16)
+
+## Technical Design
+
+### Approach
+
+Add test files for the two major zero-coverage areas: the controller reconciliation loop and the REST API handlers. Both use the controller-runtime **fake client** (not envtest) to avoid requiring K8s binaries in CI. API handler tests use `httptest` with Echo. Tests are table-driven with `t.Run` subtests. The namespace isolation cross-namespace test is added as a mandatory security regression test. No new production code changes; this design is test-only.
+
+### Changes Required
+
+**New file: `internal/controller/application_controller_test.go`**
+- Package `controller` (whitebox — same package as controller)
+- Imports: `testing`, `context`, `github.com/dlapiduz/iaf/api/v1alpha1`, `sigs.k8s.io/controller-runtime/pkg/client/fake`, `sigs.k8s.io/controller-runtime/pkg/reconcile`, `k8s.io/apimachinery/pkg/runtime`, `k8s.io/apimachinery/pkg/types`
+- Helper `newScheme()` — registers `iafv1alpha1`, `appsv1`, `corev1`, and `unstructured` (for kpack/Traefik)
+- Helper `newReconciler(objs ...client.Object) *ApplicationReconciler` — builds fake client with scheme, constructs reconciler with test values (`ClusterBuilder: "test-builder"`, `RegistryPrefix: "ttl.sh/test"`, `BaseDomain: "test.local"`)
+- Test functions:
+
+  ```
+  TestReconcile_ImageDeploy          — image-based app → Deployment + Service + IngressRoute created, phase Running
+  TestReconcile_GitSource_BuildStart — git-source app → kpack Image CR created, phase Building, requeue
+  TestReconcile_GitSource_BuildDone  — kpack Image CR present with Succeeded status + latestImage → Deployment created
+  TestReconcile_GitSource_BuildFailed— kpack Image CR present with Failed status → phase Failed
+  TestReconcile_NoSource             — app with no image/git/blob → phase Failed
+  TestReconcile_Idempotent           — reconciling twice with same app does not error (update path)
+  ```
+
+- For kpack Image CR: use `unstructured.Unstructured` with `kpack.io/v1alpha2/Image` GVK to simulate what the fake client returns. Set `status.latestImage` and `status.conditions[0].type/status/reason` fields to simulate build outcomes.
+- Fake client note: `fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()` — the fake client supports `Create`, `Get`, `Update`, `List`, `Delete` but does NOT run webhooks or owner-reference cascade deletes. Test deletion by checking that objects are absent after calling `Delete` directly; do not test cascade via the reconciler (that is controller-runtime's responsibility, not ours).
+
+**New file: `internal/api/handlers/applications_test.go`**
+- Package `handlers_test` (blackbox — uses exported API only)
+- Imports: `testing`, `net/http`, `net/http/httptest`, `encoding/json`, `strings`, `github.com/labstack/echo/v4`, `sigs.k8s.io/controller-runtime/pkg/client/fake`, `github.com/dlapiduz/iaf/internal/auth`, `github.com/dlapiduz/iaf/internal/sourcestore`
+
+- Helper `setupHandlerTest(t) (*ApplicationHandler, *echo.Echo, *auth.SessionStore, client.Client)`:
+  ```go
+  func setupHandlerTest(t *testing.T) (*handlers.ApplicationHandler, *echo.Echo, *auth.SessionStore, client.Client) {
+      scheme := runtime.NewScheme()
+      iafv1alpha1.AddToScheme(scheme)
+      k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+      sessions := auth.NewSessionStore("")  // in-memory, no file
+      store := sourcestore.NewStore(t.TempDir())
+      h := handlers.NewApplicationHandler(k8sClient, sessions, store)
+      e := echo.New()
+      return h, e, sessions, k8sClient
+  }
+  ```
+
+- Helper `makeRequest(method, path, body string, headers map[string]string) (*httptest.ResponseRecorder, echo.Context)` — wraps `httptest.NewRequest` + `httptest.NewRecorder` + `echo.New().NewContext`.
+
+- Test cases (table-driven under `TestApplicationHandler`):
+
+  | Subtest | Endpoint | Setup | Expected |
+  |---------|----------|-------|----------|
+  | `CreateApp_OK` | `POST /api/v1/applications` | valid session, image app | 201, CR created |
+  | `CreateApp_MissingSession` | `POST /api/v1/applications` | no session header | 400, error message |
+  | `CreateApp_NoSource` | `POST /api/v1/applications` | valid session, no image/gitUrl | 400 |
+  | `ListApps_OK` | `GET /api/v1/applications` | 2 apps in namespace | 200, array len=2 |
+  | `ListApps_CrossNamespace` | `GET /api/v1/applications` | session → ns-a; apps in ns-b only | 200, empty array (isolation) |
+  | `GetApp_OK` | `GET /api/v1/applications/:name` | app exists | 200, correct name |
+  | `GetApp_NotFound` | `GET /api/v1/applications/:name` | no such app | 404 |
+  | `DeleteApp_OK` | `DELETE /api/v1/applications/:name` | app exists | 204 |
+  | `UploadSource_OK` | `POST /api/v1/applications/:name/source` | app exists, JSON body | 200, blob field set |
+
+- The `ListApps_CrossNamespace` test is the mandatory isolation regression:
+  ```go
+  // Create session bound to "ns-a"
+  sessionID := sessions.Register("ns-a")
+  // Pre-create an app in "ns-b" directly via k8sClient
+  k8sClient.Create(ctx, appInNsB)
+  // Call handler with session for "ns-a"
+  // Response must be empty array — never returns ns-b resources
+  ```
+
+**New file: `internal/api/handlers/logs_test.go`** (companion to issue #15 test design)
+- Tests for `LogsHandler.GetLogs` covering multi-pod selection and `pod_name` validation — listed in issue #15 design; included here for completeness since both test files are in the same package and depend on `internal/k8s/pods.go` from issue #15.
+- This test file should be implemented together with `logs.go` changes.
+
+**New file: `internal/middleware/auth_test.go`**
+- Tests for `Auth` middleware:
+  - Valid token → passes through (200)
+  - Missing Authorization header → 401
+  - Non-Bearer format → 401
+  - Invalid token → 401
+  - `/health` path → no auth required (200)
+  - `/sources/foo` path → no auth required (200)
+
+### Data / API Changes
+
+None — this is test-only. No production code changes.
+
+### Multi-tenancy & Shared Resource Impact
+
+The `ListApps_CrossNamespace` test codifies the namespace isolation invariant as a regression test. If someone removes `client.InNamespace(namespace)` from `handlers/applications.go`, this test will fail.
+
+### Security Considerations
+
+- **Fake client behavior**: the controller-runtime fake client does NOT enforce RBAC. The namespace isolation test works because `List` with `client.InNamespace("ns-a")` filters results by namespace label selector — this is controller-runtime fake client behavior, not real K8s RBAC. The test validates that the handler passes the correct namespace to the List call.
+- **No real secrets or tokens** in test fixtures — use test values like `"test-session-id"`, `"test-token"`.
+- **`auth.SessionStore` initialization**: issue #16 asks for missing-session-ID → 400 test. The `NewSessionStore("")` (empty path) must work without creating a file — check `internal/auth/session.go` for file-backed initialization. If it always creates a file, the test helper may need to use `t.TempDir()` for the session store path too.
+
+### Resource & Performance Impact
+
+- Tests run entirely in-process; no K8s binaries, no ports, no network.
+- Each test creates its own fake client and session store — no shared state between subtests.
+
+### Migration / Compatibility
+
+- No breaking changes; purely additive test files.
+- `make test` will pick these up automatically (standard Go test discovery).
+
+### Open Questions for Developer
+
+1. **`auth.NewSessionStore` signature**: confirm whether `NewSessionStore("")` or `NewSessionStore(t.TempDir())` is needed for in-memory-only use. If the store always tries to write a file, use `t.TempDir()`.
+2. **`sourcestore.NewStore` constructor**: confirm the constructor signature and whether it accepts a directory path directly.
+3. **Fake client + `unstructured`**: `fake.NewClientBuilder().WithScheme(scheme)` — for kpack `Image` CRs (unstructured), you may need to register the GVK via `scheme.AddToGroupVersion` or use `WithObjects` with a pre-built unstructured object. Test this early; unstructured fake client behavior can be tricky.
+4. **`reconcile.Request` construction**: use `reconcile.Request{NamespacedName: types.NamespacedName{Name: "myapp", Namespace: "ns-a"}}` — standard pattern.
+5. **Phase assertions**: after reconcile, fetch the updated Application CR via `k8sClient.Get` and assert `app.Status.Phase`. The fake client's `Update`/`Status().Update()` calls are tracked in-memory.
+6. **Controller `setRunning` calls `Status().Update()`**: make sure the test scheme includes all needed types so the fake client's status subresource update works. You may need `.WithStatusSubresource(&iafv1alpha1.Application{})` on the fake client builder.


### PR DESCRIPTION
## Summary

- **Issue #15**: Fix pod selection in `app_logs` MCP tool and REST handler to use most-recently-started pod (sort by `CreationTimestamp` desc). Add optional `pod_name` parameter validated via label selector for isolation. Return `availablePods` list. Extract shared logic to new `internal/k8s/pods.go`.
- **Issue #16**: Design controller tests (fake client, no envtest) and REST API handler tests (httptest + Echo), including mandatory namespace isolation regression test.

## Test plan

- [ ] Review pod selection logic in `docs/architecture/issue-15-app-logs-multi-replica.md`
- [ ] Review controller and API handler test patterns in `docs/architecture/issue-16-test-coverage.md`
- [ ] Verify namespace isolation test design in issue #16 doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)