### PR TITLE
Architecture: observability stack — issues #29 #30 #31 #33 #36 #37

### DIFF
--- a/docs/architecture/issue-29-kube-prometheus-stack.md
+++ b/docs/architecture/issue-29-kube-prometheus-stack.md
@@ -1,0 +1,242 @@
+# Architecture: kube-prometheus-stack + Platform Instrumentation (Issue #29)
+
+## Technical Design
+
+### Approach
+
+Deploy kube-prometheus-stack (Prometheus Operator + Prometheus + Alertmanager + Grafana + node-exporter + kube-state-metrics) via **Helmfile** — a declarative wrapper around Helm that makes installs and upgrades a single `helmfile apply` command. The IAF apiserver, mcpserver, and controller each expose a `/metrics` endpoint; `ServiceMonitor` CRs tell Prometheus where to scrape. The `Application` CRD gains an optional `spec.metrics` field; when enabled, the controller creates a `ServiceMonitor` in the app's namespace. Grafana dashboards are provisioned via ConfigMap. This design also covers the Helmfile structure that issues #31 (Loki) and #36 (Tempo) will extend.
+
+### Changes Required
+
+**New file: `config/helmfile.yaml`** — root Helmfile, installed by `make setup-local`:
+```yaml
+repositories:
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+
+releases:
+  - name: kube-prometheus-stack
+    namespace: monitoring
+    chart: prometheus-community/kube-prometheus-stack
+    version: "69.x"          # pin major+minor; patch auto-upgradeable
+    values:
+      - helm-values/kube-prometheus-stack.yaml
+```
+
+**New file: `config/helm-values/kube-prometheus-stack.yaml`** — local-cluster values:
+```yaml
+prometheus:
+  prometheusSpec:
+    # Scrape ServiceMonitors in ALL namespaces (needed for agent namespace monitors)
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorNamespaceSelector: {}
+    serviceMonitorSelector: {}
+    retention: 7d
+    resources:
+      requests: { cpu: 100m, memory: 256Mi }
+      limits: { memory: 1Gi }
+
+grafana:
+  adminPassword: "iaf-dev-grafana"   # dev only; rotate in prod
+  ingress:
+    enabled: false   # we provision a Traefik IngressRoute separately
+  sidecar:
+    dashboards:
+      enabled: true
+      searchNamespace: monitoring    # picks up dashboard ConfigMaps
+    datasources:
+      enabled: true
+
+alertmanager:
+  enabled: false   # not needed for local dev
+
+nodeExporter:
+  enabled: true
+
+kubeStateMetrics:
+  enabled: true
+```
+
+**New file: `config/deploy/grafana-ingressroute.yaml`** — Traefik IngressRoute for Grafana:
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  entryPoints: [web]
+  routes:
+    - match: Host(`grafana.localhost`)
+      kind: Rule
+      services:
+        - name: kube-prometheus-stack-grafana
+          port: 80
+```
+
+**Updated `Makefile`**:
+- `setup-local` target: add `helmfile apply -f config/helmfile.yaml` after namespace creation
+- Prerequisite check: `helmfile version` — fail clearly if helmfile not installed, print install link
+- Add `make update-platform` target that runs `helmfile apply -f config/helmfile.yaml` for upgrades
+
+**New file: `config/deploy/monitoring-namespace.yaml`** — ensures `monitoring` namespace exists before Helm install:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+```
+
+**Updated `api/v1alpha1/application_types.go`** — add `spec.metrics` field:
+```go
+type MetricsConfig struct {
+    // +kubebuilder:default=false
+    Enabled bool  `json:"enabled"`
+    // Port defaults to spec.port if zero
+    Port    int32 `json:"port,omitempty"`
+    // +kubebuilder:default="/metrics"
+    Path    string `json:"path,omitempty"`
+}
+
+type ApplicationSpec struct {
+    // ... existing fields ...
+    // +optional
+    Metrics *MetricsConfig `json:"metrics,omitempty"`
+}
+```
+
+**New file: `internal/k8s/servicemonitor.go`** — builds `ServiceMonitor` unstructured CR:
+```go
+var ServiceMonitorGVK = schema.GroupVersionKind{
+    Group:   "monitoring.coreos.com",
+    Version: "v1",
+    Kind:    "ServiceMonitor",
+}
+
+func BuildServiceMonitor(app *iafv1alpha1.Application) *unstructured.Unstructured
+```
+- Selector: `matchLabels: {iaf.io/application: <name>}` (same labels the controller already sets on the Service)
+- Endpoint: `port: "http"` (named port on the Service), `path: app.Spec.Metrics.Path`
+- Owner reference: the `Application` CR → auto-deleted when app is deleted
+- Label `release: kube-prometheus-stack` so Prometheus Operator picks it up
+
+**Updated `internal/controller/application_controller.go`**:
+- Add `reconcileServiceMonitor(ctx, app)` called after `reconcileService`
+- If `app.Spec.Metrics != nil && app.Spec.Metrics.Enabled`: create/update `ServiceMonitor`
+- If `app.Spec.Metrics == nil || !app.Spec.Metrics.Enabled`: delete `ServiceMonitor` if it exists (cleanup on disable)
+- RBAC marker: `+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete`
+
+**Updated `cmd/apiserver/main.go`**:
+- Add `promhttp.Handler()` on a separate `IAF_METRICS_PORT` (default `9091`, not 9090 to avoid Prometheus port conflict)
+- Start metrics server in a goroutine alongside the main Echo server
+- Register custom metrics with `prometheus/client_golang` (see metrics list below)
+
+**Updated `cmd/mcpserver/main.go`**:
+- Same metrics server pattern on its own port (default `9092`)
+
+**Updated `cmd/controller/main.go`**:
+- controller-runtime already exposes `/metrics` via `ctrl.Manager`; ensure `BindMetricsAddress` is set (default `:8080` in ctrl — rename to `:9090`)
+- Register custom IAF metrics on the controller-runtime registry
+
+**New file: `internal/metrics/platform.go`** — central registry for platform metrics:
+```go
+var (
+    SessionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+        Name: "iaf_sessions_total",
+        Help: "Total sessions created.",
+    })
+    SessionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
+        Name: "iaf_sessions_active",
+        Help: "Currently active sessions.",
+    })
+    ApplicationsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+        Name: "iaf_applications_by_phase",
+        Help: "Application count by phase.",
+    }, []string{"phase"})
+    ReconcileDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+        Name:    "iaf_reconcile_duration_seconds",
+        Help:    "Controller reconcile loop duration.",
+        Buckets: prometheus.DefBuckets,
+    })
+    APIRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+        Name:    "iaf_api_request_duration_seconds",
+        Help:    "REST API request duration.",
+        Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+    }, []string{"method", "path", "status"})
+    SourceStoreBytesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+        Name: "iaf_source_store_bytes_total",
+        Help: "Total bytes in the source store.",
+    })
+)
+
+func Register(reg prometheus.Registerer) { ... }
+```
+
+**Updated `internal/middleware/metrics.go`** (new file) — Echo middleware that records `iaf_api_request_duration_seconds`
+
+**New file: `config/grafana/dashboards/platform-health.json`** — Platform Health dashboard JSON:
+- Panels: active sessions, apps by phase, API request rate, p99 latency, reconcile duration, source store bytes
+- Provisioned via a ConfigMap with `grafana_dashboard: "1"` label (picked up by kube-prometheus-stack sidecar)
+
+**New file: `config/grafana/dashboards/application-overview.json`** — Application Overview dashboard:
+- Template variable: `namespace` (regex `iaf-.*`)
+- Panels: pod CPU/memory (kube-state-metrics), replica count, HTTP request rate (when app metrics enabled)
+
+**New file: `config/deploy/grafana-dashboards-configmap.yaml`** — wraps dashboards in ConfigMap:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iaf-grafana-dashboards
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+```
+
+**New file: `config/deploy/platform-servicemonitors.yaml`** — `ServiceMonitor` CRs for IAF platform components:
+- One each for apiserver, mcpserver, controller, pointing to their metrics ports
+
+**Test files**:
+- `internal/k8s/servicemonitor_test.go` — `TestBuildServiceMonitor`: verify selector, labels, port, path
+- `internal/controller/application_controller_test.go` — extend with `TestReconcile_MetricsEnabled`: confirm `ServiceMonitor` created; `TestReconcile_MetricsDisabled`: confirm `ServiceMonitor` absent
+- `internal/metrics/platform_test.go` — `TestSessionsTotal`: counter increments on register
+
+### Data / API Changes
+
+**`ApplicationSpec`** — new optional field `metrics *MetricsConfig`.
+
+**`ApplicationResponse`** (REST API) — no change needed (metrics config not surfaced in response yet; `metricsEndpoint` is a follow-on in issue #30).
+
+### Multi-tenancy & Shared Resource Impact
+
+- `ServiceMonitor` CRs are namespace-scoped to the agent's namespace. Prometheus Operator is configured with `serviceMonitorNamespaceSelector: {}` (all namespaces) — this is intentional; all agent apps report to the shared platform Prometheus.
+- **Isolation**: Prometheus has read-only access to all namespaces for scraping, but agents cannot query Prometheus directly. Grafana is the only query interface, accessible to operators only.
+- The Prometheus scrape permission (`ServiceMonitor` with matching labels) is namespace-scoped. An agent can enable/disable metrics for their own apps; they cannot create `ServiceMonitor` CRs targeting other namespaces (they don't have RBAC to create CRs in `monitoring`).
+
+### Security Considerations
+
+- **Grafana admin credentials**: default `iaf-dev-grafana` is for local dev only. `make setup-local` must print a warning: "Change the Grafana admin password before exposing to any network." Production should use `grafana.adminPassword` from a K8s Secret rather than a Helm value.
+- **Prometheus `/metrics` exposure**: controller-runtime's `/metrics` exposes Go runtime stats and controller-runtime internals — no secrets exposed. Review before enabling external access.
+- **`ServiceMonitor` label requirement**: the `release: kube-prometheus-stack` label on `ServiceMonitor` CRs is what allows Prometheus Operator to pick them up. If an agent could craft a CR with this label pointing to another app's port, they could cause scrape-rate increases but not access data. Acceptable risk.
+- **Anonymous Grafana access**: `grafana.auth.anonymous.enabled` must be `false` (the default). Explicitly set in values file to prevent accidental override.
+- **Needs security review**: flag `needs-security-review` label.
+
+### Resource & Performance Impact
+
+- kube-prometheus-stack adds ~4 pods to `monitoring` namespace; on a local Rancher Desktop cluster, set reduced resource requests in values (included above).
+- `ServiceMonitor` per app: negligible — Prometheus Operator handles thousands of monitors. Each adds one scrape target to Prometheus.
+- Custom metrics in `internal/metrics/platform.go`: all in-process; negligible CPU/memory.
+
+### Migration / Compatibility
+
+- `spec.metrics` is optional; existing `Application` CRs are unaffected.
+- Helmfile is a new `make setup-local` prerequisite. Add to `README.md`/`docs/` with install instructions: `brew install helmfile` (macOS), or direct binary download.
+- No CRD breaking changes (new field only).
+
+### Open Questions for Developer
+
+1. **`IAF_METRICS_PORT` default**: use `9091` for apiserver and `9092` for mcpserver to avoid conflict with Prometheus itself on `:9090`. Confirm with cluster network layout.
+2. **Dashboard provisioning**: the kube-prometheus-stack sidecar watches for ConfigMaps with label `grafana_dashboard: "1"` in the `monitoring` namespace. Confirm label selector matches the chart version's sidecar config.
+3. **`make run-helmfile` prerequisite check**: add a Makefile check that `helmfile` binary exists before calling it; print `brew install helmfile` if not found (macOS) or the GitHub releases URL.
+4. **`ServiceMonitor` port reference**: the controller already creates a Service with a `containerPort` but does not name the port. Add `name: "http"` to the Service's port definition so the `ServiceMonitor` can reference it by name rather than number.
+5. **controller-runtime metrics bind address**: the default is `:8080` which conflicts with the webhook server. Confirm the correct flag (`--metrics-bind-address`) and set to `:9090` in `config/deploy/platform.yaml`.

--- a/docs/architecture/issue-30-agent-metrics-guidance.md
+++ b/docs/architecture/issue-30-agent-metrics-guidance.md
@@ -1,0 +1,154 @@
+# Architecture: Agent Metrics Guidance — MCP Resources and Prompts (Issue #30)
+
+## Technical Design
+
+### Approach
+
+Deliver the platform's metrics standard to agents through two MCP additions: a `iaf://org/metrics-standards` resource (structured JSON loaded from an embedded file, same pattern as issue #1's `iaf://org/coding-standards`) and a `metrics-guide` prompt (parameterized by language, same pattern as `language-guide`). Additionally, update `deploy_app`/`push_code` to accept a `metrics` parameter, update the controller to set `app.kubernetes.io/version` on Deployments, and add `metricsEndpoint` to `app_status` responses. These changes depend on issue #29 (`spec.metrics` CRD field) being implemented first.
+
+### Changes Required
+
+**New file: `config/org-standards/metrics-standards.json`** (embedded):
+```json
+{
+  "version": "1.0",
+  "method": "RED",
+  "endpoint": {
+    "path": "/metrics",
+    "portSource": "same as spec.port unless spec.metrics.port is set",
+    "format": "prometheus-text"
+  },
+  "requiredMetrics": [
+    {
+      "name": "http_requests_total",
+      "type": "counter",
+      "labels": ["method", "path", "status_code"],
+      "description": "Total HTTP requests by method, path, and status code."
+    },
+    {
+      "name": "http_request_duration_seconds",
+      "type": "histogram",
+      "buckets": [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
+      "labels": ["method", "path"],
+      "description": "HTTP request duration in seconds."
+    }
+  ],
+  "standardLabels": {
+    "app": "Set automatically from pod label app.kubernetes.io/name (set by IAF controller)",
+    "version": "Set automatically from pod label app.kubernetes.io/version"
+  },
+  "registration": {
+    "how": "Set spec.metrics.enabled=true in deploy_app or push_code",
+    "verify": "Poll app_status for metricsEndpoint field"
+  },
+  "histogramBuckets": [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5]
+}
+```
+This file is overridable by operators at `IAF_METRICS_STANDARDS_FILE` (same pattern as issue #1).
+
+**New file: `internal/mcp/resources/metrics_standards.go`**:
+- `RegisterMetricsStandards(server *gomcp.Server, deps *tools.Dependencies)`
+- Mirrors the pattern in `internal/orgstandards/loader.go` (issue #1): use `deps.MetricsStandardsLoader` (a `*orgstandards.Loader`) to read content, or fall back to the embedded default if no override is configured
+- URI: `iaf://org/metrics-standards`; MIMEType: `application/json`
+
+**New file: `internal/mcp/prompts/metrics_guide.go`**:
+- `RegisterMetricsGuide(server *gomcp.Server, deps *tools.Dependencies)`
+- Same structure as `language_guide.go`: `language` argument; `metricsGuides` map keyed by language alias
+- Content per language (hardcoded Markdown in the Go file — no embedded file needed):
+
+  | Language | Client library | Minimal import |
+  |----------|---------------|----------------|
+  | Go | `github.com/prometheus/client_golang/prometheus` | `promhttp.Handler()` |
+  | Node.js | `prom-client` | `npm install prom-client` |
+  | Python | `prometheus_client` | `pip install prometheus-client` |
+  | Java | `io.micrometer:micrometer-registry-prometheus` | Spring Boot Actuator auto-config |
+  | Ruby | `prometheus-client` | `gem install prometheus-client` |
+
+- Guide structure per language:
+  1. Library installation
+  2. Expose `/metrics` endpoint (minimal working code)
+  3. Instrument HTTP requests with RED counters/histograms
+  4. How to set `spec.metrics.enabled: true` via `deploy_app` or `push_code`
+  5. Verify: `app_status` returns `metricsEndpoint`
+
+**Updated `internal/mcp/tools/deploy.go`** (`DeployAppInput`):
+```go
+type MetricsInput struct {
+    Enabled bool   `json:"enabled"`
+    Port    int32  `json:"port,omitempty"`
+    Path    string `json:"path,omitempty"`
+}
+
+type DeployAppInput struct {
+    // ... existing fields ...
+    Metrics *MetricsInput `json:"metrics,omitempty" jsonschema:"optional"`
+}
+```
+- When `input.Metrics != nil`, set `app.Spec.Metrics = &iafv1alpha1.MetricsConfig{...}`
+- Response struct: add `MetricsRegistered bool` field; set to `input.Metrics != nil && input.Metrics.Enabled`
+
+**Updated `internal/mcp/tools/push_code.go`** — same `Metrics *MetricsInput` field addition.
+
+**Updated `internal/mcp/tools/status.go`** (`AppStatusOutput` or equivalent map):
+- When `app.Spec.Metrics != nil && app.Spec.Metrics.Enabled`, add `metricsEndpoint` to result:
+  ```go
+  metricsEndpoint = fmt.Sprintf("http://%s.%s%s", app.Name, deps.BaseDomain, metricsPath)
+  ```
+
+**Updated `internal/controller/application_controller.go`** — `reconcileDeployment`:
+- Add `app.kubernetes.io/version` label to Deployment and pod template:
+  ```go
+  version := "unknown"
+  if app.Status.LatestImage != "" {
+      // extract tag from image reference, e.g. "registry/img:sha256-abc" → "sha256-abc"
+      if parts := strings.SplitN(app.Status.LatestImage, ":", 2); len(parts) == 2 {
+          version = parts[1]
+      }
+  }
+  labels["app.kubernetes.io/version"] = sanitizeLabelValue(version)
+  ```
+- `sanitizeLabelValue(s string) string` — truncate to 63 chars, replace invalid chars with `-` (K8s label value rules: `[a-z0-9A-Z-._]`, max 63 chars, no leading/trailing `-._`)
+
+**Updated `internal/mcp/server.go`**:
+- Call `resources.RegisterMetricsStandards(server, deps)` and `prompts.RegisterMetricsGuide(server, deps)`
+
+**Updated `internal/mcp/resources/resources_test.go`** — add `TestMetricsStandards` test.
+
+**New file: `internal/mcp/prompts/metrics_guide_test.go`**:
+- Table-driven: for each language (`go`, `nodejs`, `python`, `java`, `ruby`), call `metrics-guide` prompt and verify response contains library name and `/metrics` path
+
+### Data / API Changes
+
+**`DeployAppInput`** — new optional `metrics` field.
+**`AppStatusOutput`** — new optional `metricsEndpoint` string field.
+**`iaf://org/metrics-standards`** — new MCP resource.
+**`metrics-guide`** — new MCP prompt.
+**Deployment labels** — `app.kubernetes.io/version` added (non-breaking; new label only).
+
+### Multi-tenancy & Shared Resource Impact
+
+`iaf://org/metrics-standards` is a global read-only resource — no tenant data, safe for all agents to read. The `metricsEndpoint` URL is derived from the app's own name and the platform's `BaseDomain` — no cross-tenant information leakage. Prometheus scraping is the shared resource; the `ServiceMonitor` design in issue #29 ensures it is scoped to the correct namespace.
+
+### Security Considerations
+
+- **Label value sanitization**: `app.kubernetes.io/version` is derived from `app.Status.LatestImage`, which itself comes from the kpack build output (not directly from user input). Still, the image tag can contain arbitrary characters — `sanitizeLabelValue` is required to avoid rejected Deployment specs.
+- **`metricsEndpoint` URL generation**: uses `app.Name` (already validated by issue #14) and platform `BaseDomain` — no injection risk.
+- `iaf://org/metrics-standards` is read-only, platform-controlled content. Operators who update via `IAF_METRICS_STANDARDS_FILE` are trusted (same trust level as platform config).
+
+### Resource & Performance Impact
+
+- New MCP resource and prompt: in-memory, negligible.
+- Label injection on Deployments: adds one label per Deployment update — negligible.
+
+### Migration / Compatibility
+
+- `metrics` field on `deploy_app`/`push_code` is optional — existing callers unaffected.
+- Deployment label addition is non-breaking (new label only; existing workloads unaffected until next reconcile).
+- Depends on issue #29 `spec.metrics` CRD field being deployed first.
+
+### Open Questions for Developer
+
+1. **`MetricsStandardsLoader` in `Dependencies`**: add `MetricsStandardsLoader *orgstandards.Loader` to `tools.Dependencies`. Wire it in `cmd/apiserver/main.go` and `cmd/mcpserver/main.go` using the same `IAF_METRICS_STANDARDS_FILE` env var pattern (or use a dedicated `IAF_METRICS_STANDARDS_FILE` var to allow separate operator overrides).
+2. **Image tag extraction**: `strings.SplitN(image, ":", 2)` breaks for digest-only references like `registry/img@sha256:abc`. Handle the `@sha256:` case separately if needed.
+3. **`metricsEndpoint` TLS**: once issue #12 (TLS) is implemented, the `metricsEndpoint` URL should use `https://` when TLS is enabled. For now, always `http://`.
+4. **`deploy_app` response**: currently returns a string message. The `MetricsRegistered` bool should be added to the response struct (or map). Confirm the existing return type to avoid breaking the MCP schema.

--- a/docs/architecture/issue-31-loki-log-aggregation.md
+++ b/docs/architecture/issue-31-loki-log-aggregation.md
@@ -1,0 +1,240 @@
+# Architecture: Loki + Grafana Alloy for Log Aggregation (Issue #31)
+
+## Technical Design
+
+### Approach
+
+Add Loki (single-binary, filesystem storage) and Grafana Alloy (DaemonSet log collector) to the existing Helmfile at `config/helmfile.yaml`, extending the observability stack from issue #29. Loki is provisioned as a Grafana datasource via ConfigMap. The `app_logs` MCP tool gains optional Loki integration: when `IAF_LOKI_URL` is set, it queries the Loki HTTP API for historical logs; otherwise it falls back to the existing K8s pod logs behavior unchanged. Platform components switch to structured JSON logging.
+
+### Changes Required
+
+**Updated `config/helmfile.yaml`** — add Loki and Alloy releases after kube-prometheus-stack:
+```yaml
+repositories:
+  - name: grafana
+    url: https://grafana.github.io/helm-charts
+  # (prometheus-community already present from issue #29)
+
+releases:
+  # ... kube-prometheus-stack (issue #29) ...
+
+  - name: loki
+    namespace: monitoring
+    chart: grafana/loki
+    version: "6.x"
+    values:
+      - helm-values/loki.yaml
+
+  - name: grafana-alloy
+    namespace: monitoring
+    chart: grafana/alloy
+    version: "0.x"
+    values:
+      - helm-values/grafana-alloy.yaml
+```
+
+**New file: `config/helm-values/loki.yaml`**:
+```yaml
+loki:
+  auth_enabled: false    # single-tenant mode; multi-tenant is a future concern
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    size: 5Gi
+
+# Disable components not needed in single-binary mode
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+```
+
+**New file: `config/helm-values/grafana-alloy.yaml`**:
+```yaml
+alloy:
+  configMap:
+    create: true
+    content: |
+      // Kubernetes pod log discovery
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      // Relabel: extract namespace, pod, container, app label
+      discovery.relabel "pod_logs" {
+        targets = discovery.kubernetes.pods.targets
+        rule { source_labels = ["__meta_kubernetes_namespace"] target_label = "namespace" }
+        rule { source_labels = ["__meta_kubernetes_pod_name"] target_label = "pod" }
+        rule { source_labels = ["__meta_kubernetes_pod_container_name"] target_label = "container" }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          target_label  = "app"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          regex         = "iaf-.*"
+          target_label  = "component"
+          replacement   = "app"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          regex         = "iaf-system"
+          target_label  = "component"
+          replacement   = "platform"
+        }
+      }
+
+      loki.source.kubernetes "pod_logs" {
+        targets    = discovery.relabel.pod_logs.output
+        forward_to = [loki.write.default.receiver]
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+        }
+      }
+
+# DaemonSet mode for node-level log access
+controller:
+  type: daemonset
+
+# RBAC needed for pod log access
+rbac:
+  create: true
+```
+
+**New file: `config/deploy/loki-datasource-configmap.yaml`** — Grafana datasource ConfigMap:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-datasource
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+data:
+  loki-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        url: http://loki.monitoring.svc.cluster.local:3100
+        access: proxy
+        isDefault: false
+```
+
+**New file: `config/grafana/dashboards/platform-logs.json`** — Platform Logs dashboard:
+- Log panel per component (`apiserver`, `controller`, `mcpserver`) filtered by `component="platform"`
+- Error rate panel: `sum(count_over_time({component="platform", level="error"}[5m]))`
+- Wrapped in ConfigMap in `config/deploy/grafana-dashboards-configmap.yaml` (extend existing)
+
+**Updated `internal/mcp/tools/logs.go`** — `RegisterAppLogsWithClientset`:
+
+```go
+// New optional input field:
+type AppLogsInput struct {
+    // ... existing fields ...
+    Since   string `json:"since,omitempty" jsonschema:"optional - time duration (e.g. 1h, 30m) or RFC3339 timestamp for historical log queries via Loki"`
+}
+```
+
+Add `LokiURL string` to `tools.Dependencies` (read from `IAF_LOKI_URL` env var).
+
+When `deps.LokiURL != ""`:
+1. Build LogQL query: `{namespace="<ns>", app="<appName>"}` — namespace from `deps.ResolveNamespace`
+2. Parse `input.Since` as duration or RFC3339 timestamp → `start` parameter for Loki `/loki/api/v1/query_range`
+3. Default `since`: `time.Now().Add(-5 * time.Minute)` (returns ~100 lines of recent logs)
+4. Execute HTTP GET to `{deps.LokiURL}/loki/api/v1/query_range?query=...&start=...&limit=<lines>`
+5. Parse response: `data.result[].values[]` (each value is `[timestamp, logLine]`) → join log lines
+6. Return result with `source: "loki"` field added
+
+When `deps.LokiURL == ""`: use existing K8s pod logs path (no change to current behavior).
+
+**New file: `internal/loki/client.go`**:
+```go
+type Client struct { BaseURL string; HTTPClient *http.Client }
+type QueryResult struct { Lines []string; Source string }
+func (c *Client) QueryRange(ctx, namespace, appName, since string, limit int64) (*QueryResult, error)
+```
+This is testable in isolation — `RegisterAppLogsWithClientset` uses a `LokiQuerier` interface so tests can mock it.
+
+**New file: `internal/loki/client_test.go`** — test with `httptest.NewServer` returning canned Loki JSON responses.
+
+**Updated platform component logging** — structured JSON to stdout:
+
+*`cmd/apiserver/main.go`*: switch from Echo's default logger to `slog.NewJSONHandler(os.Stdout, nil)`. Echo has a `Logger` interface — replace with a slog-backed adapter, or use `zerolog`/`slog` for all platform logs (pick `slog` — stdlib, no dependency).
+
+*`cmd/controller/main.go`*: controller-runtime already supports `zap` logger; configure zap JSON output:
+```go
+ctrl.SetLogger(zap.New(zap.UseDevMode(false)))  // JSON in production mode
+```
+
+*`cmd/mcpserver/main.go`*: same slog pattern.
+
+Minimum fields in every platform log line: `time`, `level`, `msg`, `component`.
+
+**Tests** (new `internal/mcp/tools/logs_test.go` additions):
+- `TestAppLogs_LokiEnabled`: mock Loki server returns canned response → tool returns log lines with `source: "loki"`
+- `TestAppLogs_LokiSince_Duration`: `since: "1h"` → query `start` is ~1 hour ago
+- `TestAppLogs_LokiSince_RFC3339`: `since: "2026-01-01T00:00:00Z"` → query `start` matches timestamp
+- `TestAppLogs_LokiFallback`: `LokiURL == ""` → falls back to K8s pod logs (existing test coverage)
+- `TestAppLogs_LokiNamespaceIsolation`: LogQL query always includes `namespace=<session-ns>` label
+
+### Data / API Changes
+
+**`AppLogsInput`** — new optional `since` field.
+**MCP tool response** — new `source` field: `"loki"` or `"kubernetes"` (indicates which backend served the logs).
+**`tools.Dependencies`** — new `LokiURL string` field.
+
+### Multi-tenancy & Shared Resource Impact
+
+- **Critical isolation control**: the Loki LogQL query MUST include `namespace="<session-namespace>"`. The namespace is resolved from the session ID (via `deps.ResolveNamespace`) — never from agent-supplied input. An agent cannot query another session's logs by specifying a different app name because the namespace filter limits results to their own namespace.
+- Alloy collects logs from ALL namespaces (necessary for platform visibility). Operators have full log access. Agents access only their namespace's logs via `app_logs`.
+- Loki uses single-tenant mode (`auth_enabled: false`) — all logs in one Loki instance, isolated only by namespace label at query time. This is acceptable for the current trust model (platform operators are trusted). A future multi-tenant Loki deployment would use per-tenant token auth.
+
+### Security Considerations
+
+- **Loki namespace isolation**: the `namespace` label in the LogQL query is the only cross-tenant guard. The implementation must use `deps.ResolveNamespace(sessionID)` — never accept a namespace from agent input.
+- **Alloy RBAC**: Alloy DaemonSet needs `get`/`list`/`watch` on `pods` and `pods/log` cluster-wide. This is a highly privileged role. Document it explicitly. Ensure Alloy's ServiceAccount has no other permissions. Alloy pods must be in `monitoring` namespace, not accessible from agent namespaces.
+- **Log content**: the platform does not filter log content passed through `app_logs`. Log lines may contain sensitive data if the app logs secrets. This is the app developer's responsibility; the `logging-guide` (issue #33) explicitly prohibits logging secrets.
+- **Platform log format**: switch to structured JSON must never log token values (`Authorization` header values, `IAF_API_TOKENS`) — audit `cmd/apiserver/main.go` for any existing debug logging that might include request headers.
+- **Needs security review** label: add.
+
+### Resource & Performance Impact
+
+- Loki (single-binary): ~256Mi memory on a quiet cluster; 5Gi PVC.
+- Grafana Alloy (DaemonSet, one pod per node): ~64Mi memory per node on a local cluster.
+- `app_logs` Loki path: one HTTP call per tool invocation — negligible vs. the K8s API call it replaces.
+
+### Migration / Compatibility
+
+- `since` field is optional — existing `app_logs` callers unaffected.
+- `source` field in response is additive — existing callers that don't read it are unaffected.
+- `IAF_LOKI_URL` unset = existing behavior exactly. No behavioral change until operator sets the env var.
+- Depends on issue #29 (Helmfile structure) being deployed first.
+
+### Open Questions for Developer
+
+1. **`LokiQuerier` interface**: define `type LokiQuerier interface { QueryRange(ctx, ns, app, since string, limit int64) ([]string, error) }` in `internal/mcp/tools/logs.go` so the real Loki client and a mock can satisfy it. Wire real client when `deps.LokiURL != ""`.
+2. **Loki response format**: the `/loki/api/v1/query_range` response wraps log lines as `[unixNano, logLine]` pairs. Parse carefully — unixNano is a string in Loki's JSON.
+3. **`since` format**: support both `"1h"`, `"30m"` (Go duration syntax) and RFC3339 timestamps. `time.ParseDuration` for the first; `time.Parse(time.RFC3339, ...)` for the second. Return a clear error if neither parses.
+4. **Log line ordering**: Loki returns results oldest-first by default. Consider reversing for `app_logs` to match the existing K8s pod logs behavior (newest lines last).
+5. **Platform log migration**: switching `cmd/controller/main.go` to zap JSON mode changes all controller-runtime log output format. Verify no existing log parsing (e.g., in tests) depends on the current format.

--- a/docs/architecture/issue-33-agent-logging-guidance.md
+++ b/docs/architecture/issue-33-agent-logging-guidance.md
@@ -1,0 +1,155 @@
+# Architecture: Agent Logging Guidance — MCP Resources and Prompts (Issue #33)
+
+## Technical Design
+
+### Approach
+
+Deliver the platform's logging standard to agents through a `iaf://org/logging-standards` resource (structured JSON, embedded file, same pattern as `iaf://org/metrics-standards`) and a `logging-guide` prompt (parameterized by language, same pattern as `metrics-guide`). No new K8s objects, no controller changes — logging is automatic once agents write to stdout in the correct format. This depends on issue #31 (Loki infrastructure) being deployed, but the MCP resource and prompt can ship independently.
+
+### Changes Required
+
+**New file: `config/org-standards/logging-standards.json`** (embedded default):
+```json
+{
+  "version": "1.0",
+  "output": {
+    "target": "stdout",
+    "format": "ndjson",
+    "description": "One JSON object per line (JSON Lines / NDJSON). Do not log to files. Kubernetes captures stdout automatically; Grafana Alloy ships it to Loki."
+  },
+  "requiredFields": [
+    {"name": "time",  "type": "string", "format": "RFC3339", "example": "2026-02-19T14:23:01Z"},
+    {"name": "level", "type": "string", "values": ["debug","info","warn","error"], "example": "info"},
+    {"name": "msg",   "type": "string", "description": "Human-readable message", "example": "request completed"}
+  ],
+  "recommendedFields": [
+    {"name": "app",         "description": "IAF application name — matches Application CR name"},
+    {"name": "req_id",      "description": "Request ID from X-Request-ID header"},
+    {"name": "method",      "description": "HTTP method for request logs"},
+    {"name": "path",        "description": "HTTP path for request logs"},
+    {"name": "status",      "description": "HTTP status code (integer)"},
+    {"name": "duration_ms", "description": "Request duration in milliseconds (float)"},
+    {"name": "error",       "description": "Error message; only on level=error"},
+    {"name": "trace_id",    "description": "OTel trace ID for trace-log correlation (see iaf://org/tracing-standards)"},
+    {"name": "span_id",     "description": "OTel span ID for trace-log correlation"}
+  ],
+  "prohibited": [
+    "API tokens, passwords, or any value from a Kubernetes Secret",
+    "Full request or response bodies (unless in debug mode with explicit opt-in)",
+    "PII: names, emails, phone numbers, IP addresses unless required and documented"
+  ],
+  "collection": {
+    "how": "Automatic — Grafana Alloy DaemonSet tails all pod stdout and ships to Loki",
+    "query": "Use app_logs MCP tool; operators use Grafana Explore with namespace filter"
+  }
+}
+```
+Overridable via `IAF_LOGGING_STANDARDS_FILE` env var.
+
+**New file: `internal/mcp/resources/logging_standards.go`**:
+- `RegisterLoggingStandards(server *gomcp.Server, deps *tools.Dependencies)`
+- URI: `iaf://org/logging-standards`; MIMEType: `application/json`
+- Load from `deps.LoggingStandardsLoader` (optional override) or embedded default
+- Pattern identical to `metrics_standards.go`
+
+**New file: `internal/mcp/prompts/logging_guide.go`**:
+- `RegisterLoggingGuide(server *gomcp.Server, deps *tools.Dependencies)`
+- `language` argument (optional); same alias map as `language_guide.go`
+- `loggingGuides` map per language:
+
+  | Language | Library | Notes |
+  |----------|---------|-------|
+  | Go | `log/slog` (stdlib) | `slog.NewJSONHandler(os.Stdout, nil)` |
+  | Node.js | `pino` | NDJSON to stdout by default |
+  | Python | `structlog` + `python-json-logger` | configure `ProcessorFormatter` for JSON output |
+  | Java | `logback` + `logstash-logback-encoder` | `<appender class="ch.qos.logback.core.ConsoleAppender">` |
+  | Ruby | `semantic_logger` | `SemanticLogger.add_appender(io: $stdout, formatter: :json)` |
+
+- Each language entry includes:
+  1. Install command
+  2. Initialization snippet (copy-paste ready — ~5 lines)
+  3. Example: log HTTP request with all recommended fields
+  4. Example: log an error with `error` field
+  5. `LOG_LEVEL` env var support (bonus guidance per open question)
+  6. Explicit note: "Log to stdout only. Do not configure file appenders or log shippers."
+  7. "Do not log secrets, tokens, or env var values" warning
+  8. Verify: `app_logs <your-app>` after deploy
+
+**Updated `internal/mcp/server.go`**:
+- Call `resources.RegisterLoggingStandards(server, deps)`
+- Call `prompts.RegisterLoggingGuide(server, deps)`
+
+**Updated `tools.Dependencies`** (`internal/mcp/tools/deps.go`):
+```go
+type Dependencies struct {
+    // ... existing fields ...
+    LoggingStandardsLoader *orgstandards.Loader  // nil = use embedded default
+}
+```
+
+**Updated `config/org-standards/coding-standards.json`** (issue #1 file):
+- Add `"logging"` section pointing to `iaf://org/logging-standards`:
+  ```json
+  "logging": {
+    "standard": "iaf://org/logging-standards",
+    "summary": "Log to stdout in JSON Lines format. Use the logging-guide prompt for language-specific setup."
+  }
+  ```
+
+**Updated `internal/mcp/prompts/deploy_guide.go`**:
+- Add a "Logging" section to the deploy-guide text:
+  ```
+  ## Logging
+  Log to stdout in JSON Lines format. Logs are automatically collected by the platform.
+  - Get the full guide: use the `logging-guide` prompt
+  - See the standard: read resource `iaf://org/logging-standards`
+  ```
+
+**Updated `internal/mcp/prompts/metrics_guide.go`** (issue #30 file):
+- Add note: "Request logs complement RED metrics — log every request AND emit `http_request_duration_seconds`."
+
+**Updated `internal/mcp/prompts/language_guide.go`**:
+- Each language's `bestPractices` field: append "Use structured JSON logging (see `logging-guide` prompt)."
+
+**Test files**:
+
+`internal/mcp/resources/logging_standards_test.go` (or extend `resources_test.go`):
+- `TestLoggingStandards_ReturnsValidJSON`: resource returns parseable JSON with `requiredFields`, `prohibited`, `output` keys
+
+`internal/mcp/prompts/logging_guide_test.go`:
+- Table-driven test for each language: verify response contains the library name and the word `stdout`
+- `TestLoggingGuide_NoLanguage`: returns generic guidance (fallback behavior — same as `language-guide`)
+
+### Data / API Changes
+
+- New MCP resource: `iaf://org/logging-standards`
+- New MCP prompt: `logging-guide`
+- No K8s object changes, no CRD changes, no REST API changes.
+
+### Multi-tenancy & Shared Resource Impact
+
+`iaf://org/logging-standards` is global and read-only — no tenant data. No shared resource impact.
+
+### Security Considerations
+
+- The standard explicitly **prohibits logging secrets**. This is a guardrail (instruction to agents), not enforcement. Enforcement requires log scanning — out of scope, but the prohibition must be present and prominent in the resource JSON and the guide.
+- The `prohibited` list in the standards JSON is what agents read before writing logging code. It is the first line of defense against accidental secret leakage into Loki.
+- `trace_id` and `span_id` fields in recommended fields: these are non-sensitive correlation IDs. Including them does not leak tenant data.
+
+### Resource & Performance Impact
+
+- New MCP resource and prompt: in-memory, negligible.
+- No additional K8s objects.
+
+### Migration / Compatibility
+
+- No breaking changes — additive only.
+- `LOG_LEVEL` env var guidance in the prompt is informational; no platform enforcement.
+- Dependencies: can ship independently of issue #31 (the resource and prompt are useful without Loki, since agents benefit from knowing the format even before log aggregation is deployed).
+
+### Open Questions for Developer
+
+1. **`LoggingStandardsLoader` wiring**: add to `Dependencies` struct and wire in `cmd/mcpserver/main.go` from `IAF_LOGGING_STANDARDS_FILE` env var. Follow exact same pattern as `CodingStandardsLoader` from issue #1.
+2. **`logging-guide` fallback language**: when `language` argument is not provided, return a language-agnostic overview with references to run `logging-guide` with a specific language. Same pattern as `language-guide`.
+3. **`structlog` vs `python-json-logger` for Python**: use `python-json-logger` (`pip install python-json-logger`) as the primary recommendation — simpler API. Mention `structlog` as an alternative for those wanting richer context binding.
+4. **`MetricsStandardsLoader` and `LoggingStandardsLoader`**: these follow the same pattern. Consider a generic `StandardsLoader` type parameterized by file path, or keep them as separate `*orgstandards.Loader` instances — the simpler approach, given there are only a few standards files.

--- a/docs/architecture/issue-36-tempo-otel-tracing.md
+++ b/docs/architecture/issue-36-tempo-otel-tracing.md
@@ -1,0 +1,266 @@
+# Architecture: Grafana Tempo + OpenTelemetry Collector for Distributed Tracing (Issue #36)
+
+## Technical Design
+
+### Approach
+
+Add Grafana Tempo (single-binary, filesystem storage) and the OpenTelemetry Collector (central Deployment, not DaemonSet — traces are push-based via OTLP) to the existing Helmfile at `config/helmfile.yaml`, extending the stack from issues #29 and #31. The OTel Collector is exposed as a `ClusterIP` Service at `otel-collector.monitoring.svc.cluster.local:4317/4318`. The IAF controller injects `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, and `OTEL_RESOURCE_ATTRIBUTES` into every Deployment it creates (when `IAF_OTEL_ENDPOINT` is set). Platform components (apiserver, controller, mcpserver) are instrumented with the OTel Go SDK.
+
+### Changes Required
+
+**Updated `config/helmfile.yaml`** — add Tempo and OTel Collector releases:
+```yaml
+repositories:
+  # ... existing repos (prometheus-community, grafana) ...
+  - name: open-telemetry
+    url: https://open-telemetry.github.io/opentelemetry-helm-charts
+
+releases:
+  # ... kube-prometheus-stack, loki, grafana-alloy (issues #29, #31) ...
+
+  - name: tempo
+    namespace: monitoring
+    chart: grafana/tempo
+    version: "1.x"
+    values:
+      - helm-values/tempo.yaml
+
+  - name: opentelemetry-collector
+    namespace: monitoring
+    chart: open-telemetry/opentelemetry-collector
+    version: "0.x"
+    values:
+      - helm-values/opentelemetry-collector.yaml
+```
+
+**New file: `config/helm-values/tempo.yaml`**:
+```yaml
+tempo:
+  storage:
+    trace:
+      backend: local
+      local:
+        path: /var/tempo/traces
+  ingester:
+    trace_idle_period: 30s
+    max_block_duration: 5m
+  compactor:
+    compaction:
+      block_retention: 168h   # 7 days
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+# Receive OTLP from the OTel Collector
+tempo:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+```
+
+**New file: `config/helm-values/opentelemetry-collector.yaml`**:
+```yaml
+mode: deployment     # central deployment, not DaemonSet — traces are push-based
+
+# Expose OTLP endpoints as ClusterIP Service
+service:
+  enabled: true
+  type: ClusterIP
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc: { endpoint: "0.0.0.0:4317" }
+        http: { endpoint: "0.0.0.0:4318" }
+
+  processors:
+    batch:
+      timeout: 5s
+      send_batch_size: 1000
+    # Enrich spans with K8s pod metadata
+    k8sattributes:
+      auth_type: serviceAccount
+      passthrough: false
+      extract:
+        metadata: [k8s.namespace.name, k8s.pod.name, k8s.node.name, k8s.pod.uid]
+        labels:
+          - tag_name: app.kubernetes.io/name
+            key: app.kubernetes.io/name
+            from: pod
+
+  exporters:
+    otlp:
+      endpoint: tempo.monitoring.svc.cluster.local:4317
+      tls:
+        insecure: true   # in-cluster, no TLS needed
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [k8sattributes, batch]
+        exporters: [otlp]
+
+# RBAC for k8sattributes processor
+clusterRole:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: [pods, namespaces, nodes]
+      verbs: [get, list, watch]
+    - apiGroups: [apps]
+      resources: [replicasets]
+      verbs: [get, list, watch]
+```
+
+**New file: `config/deploy/tempo-datasource-configmap.yaml`** — Grafana datasource ConfigMap:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo-datasource
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+data:
+  tempo-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Tempo
+        type: tempo
+        url: http://tempo.monitoring.svc.cluster.local:3100
+        access: proxy
+        jsonData:
+          tracesToLogsV2:
+            datasourceUid: loki    # correlate traces → Loki logs
+            filterByTraceID: true
+            filterBySpanID: false
+            customQuery: true
+            query: '{namespace="${__span.tags["k8s.namespace.name"]}"}'
+          tracesToMetrics:
+            datasourceUid: prometheus
+            queries:
+              - name: "Request rate"
+                query: 'sum(rate(http_requests_total{namespace="$namespace", app="$app"}[5m]))'
+          serviceMap:
+            datasourceUid: prometheus
+          nodeGraph:
+            enabled: true
+```
+
+**New file: `config/grafana/dashboards/traces-overview.json`** — Traces Overview dashboard:
+- `namespace` variable (regex `iaf-.*`)
+- Panels: request rate from spans, error rate, p50/p95/p99 latency histogram, recent traces list (Tempo panel)
+- Wrapped in existing `config/deploy/grafana-dashboards-configmap.yaml`
+
+**Updated `internal/controller/application_controller.go`** — `reconcileDeployment`:
+
+Add OTel env var injection. Read `IAF_OTEL_ENDPOINT` platform env var at startup; inject into Deployments only if set:
+
+```go
+func (r *ApplicationReconciler) otelEnvVars(app *iafv1alpha1.Application) []corev1.EnvVar {
+    if r.OTelEndpoint == "" {
+        return nil
+    }
+    return []corev1.EnvVar{
+        {Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: r.OTelEndpoint},
+        {Name: "OTEL_SERVICE_NAME",            Value: app.Name},
+        {Name: "OTEL_RESOURCE_ATTRIBUTES",
+         Value: fmt.Sprintf("namespace=%s,app.version=%s", app.Namespace, sanitizedVersion(app))},
+    }
+}
+```
+
+Merge into the Deployment's container env vars **without overriding** any env var already defined by the app (agent-supplied env vars take precedence):
+```go
+// Merge: platform vars first, then app vars; app vars override
+envVars = mergeEnvVars(r.otelEnvVars(app), appEnvVars)
+```
+
+`mergeEnvVars(platform, app []corev1.EnvVar) []corev1.EnvVar` — starts with platform vars, then appends app vars if their `Name` doesn't already exist. This ensures agents can opt out by setting `OTEL_EXPORTER_OTLP_ENDPOINT=""`.
+
+New field on `ApplicationReconciler`:
+```go
+type ApplicationReconciler struct {
+    // ... existing fields ...
+    OTelEndpoint string   // from IAF_OTEL_ENDPOINT env var; empty = no injection
+}
+```
+
+Wire in `cmd/controller/main.go`: `OTelEndpoint: os.Getenv("IAF_OTEL_ENDPOINT")`.
+
+**New dependency: `go.opentelemetry.io/otel` + OTLP exporter** — for platform component instrumentation:
+
+*`cmd/apiserver/main.go`*:
+- Initialize OTel tracer provider with OTLP/HTTP exporter (endpoint from `OTEL_EXPORTER_OTLP_ENDPOINT`)
+- Wrap Echo with `otelecho.Middleware("iaf-apiserver")` (package `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho`)
+- Each HTTP request creates a root span with `http.method`, `http.route`, `http.status_code` attributes
+- Add `iaf.session_id` attribute from the `X-IAF-Session` header
+
+*`cmd/controller/main.go`*:
+- Create span per reconcile call: `ctx, span := tracer.Start(ctx, "reconcile", ...)`
+- Attributes: `iaf.app_name`, `iaf.namespace`, `iaf.phase_from`, `iaf.phase_to`
+- End span at return
+
+*`cmd/mcpserver/main.go`*:
+- Create span per MCP tool call: wrap handler invocation
+- Attributes: `mcp.tool_name`, `iaf.session_id`
+
+**Updated `config/deploy/platform.yaml`**:
+- Add `IAF_OTEL_ENDPOINT: "http://otel-collector.monitoring.svc.cluster.local:4318"` to platform component env vars (commented out by default; operators uncomment to enable)
+
+**Test files**:
+
+`internal/controller/application_controller_test.go` (extend from issue #16):
+- `TestReconcile_OTelEnvInjected`: `r.OTelEndpoint = "http://..."` → Deployment contains `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `TestReconcile_OTelEnvNotInjected`: `r.OTelEndpoint = ""` → Deployment does NOT contain `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `TestReconcile_OTelEnvNotOverridden`: app defines `OTEL_EXPORTER_OTLP_ENDPOINT` in its own env → platform value not added
+
+### Data / API Changes
+
+**`ApplicationReconciler`** — new `OTelEndpoint string` field (internal, not in CRD).
+**Deployment** (K8s resource) — new env vars `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` (when `IAF_OTEL_ENDPOINT` is set).
+**`app_status`** — gains `traceExploreUrl` field when `IAF_TEMPO_URL` is set (see issue #37 for details; this issue delivers the infrastructure, #37 delivers the MCP guidance).
+
+### Multi-tenancy & Shared Resource Impact
+
+- The OTel Collector is a **shared** central Deployment. All apps and platform components send traces to it. A misbehaving agent can flood it with high-cardinality spans, consuming Collector memory.
+  - Mitigation: `batch` processor with `send_batch_size: 1000` and `timeout: 5s` limits throughput. If volume grows, add a `memorylimiter` processor.
+- Tempo is a shared backend. Traces from all namespaces are stored together; isolation is by `k8s.namespace.name` resource attribute. Agents do not query Tempo directly (Grafana is the only interface).
+- `OTEL_EXPORTER_OTLP_ENDPOINT` points to `otel-collector.monitoring` — accessible cluster-wide. This is intentional.
+
+### Security Considerations
+
+- **OTel Collector RBAC**: `k8sattributes` processor needs `get`/`list`/`watch` on `pods`, `namespaces`, `nodes`. This is a ClusterRole. Review carefully — `nodes` access is broader than needed if all apps run in namespaced pods. If possible, restrict to `pods` and `namespaces` only (test whether `k8sattributes` works without `nodes`).
+- **OTLP endpoints not authenticated**: the OTel Collector's OTLP `4317`/`4318` ports accept spans from any pod. Spans are low-sensitivity (trace metadata, not log content). An agent can inject fake spans — acceptable risk at current scale; add authentication in a future iteration.
+- **`OTEL_SERVICE_NAME` = `app.Name`**: app name is already validated (issue #14, k8s label rules). No additional sanitization needed.
+- **`OTEL_RESOURCE_ATTRIBUTES` injection**: `app.Namespace` is a namespace name (already a validated K8s name); `sanitizedVersion()` uses the same label sanitizer from issue #30. No injection risk.
+- **Platform span attributes**: `iaf.session_id` is added to API spans. Session IDs are non-sensitive identifiers (not tokens). Confirm the session ID stored in spans does not expose the original auth token.
+- **Needs security review** label: add.
+
+### Resource & Performance Impact
+
+- Tempo (single-binary): ~256Mi memory, 5Gi PVC.
+- OTel Collector (central Deployment): ~128Mi memory on a quiet cluster.
+- OTel SDK in platform components: adds ~5-15ms per request for span creation/export (batched asynchronously — actual latency impact is negligible).
+- Env var injection on Deployments: 3 additional env vars per Deployment — negligible.
+
+### Migration / Compatibility
+
+- `IAF_OTEL_ENDPOINT` unset = no env var injection = zero behavior change for existing Deployments.
+- Existing apps already running when `IAF_OTEL_ENDPOINT` is first set will have env vars injected on next reconcile (triggering a rolling restart). This is expected and correct.
+- Depends on issues #29 and #31 (Helmfile structure and Grafana instance) being deployed first.
+
+### Open Questions for Developer
+
+1. **OTel Collector mode — Deployment vs DaemonSet**: Deployment (central) is recommended for trace collection (push-based OTLP). Grafana Alloy DaemonSet already handles log collection. Confirm this is acceptable — if the team wants a single agent, consider whether Alloy can also handle OTLP trace forwarding (it can, via its `otelcol.receiver.otlp` component; evaluate as an alternative to a separate Collector).
+2. **`mergeEnvVars` precedence**: agent-supplied vars override platform vars. The agent sets `OTEL_EXPORTER_OTLP_ENDPOINT: ""` to disable tracing — this is supported. Confirm the merge logic handles empty-string values correctly (should suppress injection, not override with empty).
+3. **`otelecho` middleware**: `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` is community-maintained. Verify it is compatible with Echo v4 (the version used by IAF).
+4. **Controller reconcile span context**: `ctrl.Request.Context()` is the parent context for reconcile. Wrap the full `Reconcile` method body in a span, not just sub-functions, to capture total reconcile duration in one trace.
+5. **`IAF_OTEL_ENDPOINT` in `cmd/apiserver/main.go`**: the apiserver itself should also export its own traces to the Collector. Wire the same env var for the apiserver's OTel exporter configuration.

--- a/docs/architecture/issue-37-agent-tracing-guidance.md
+++ b/docs/architecture/issue-37-agent-tracing-guidance.md
@@ -1,0 +1,184 @@
+# Architecture: Agent Tracing Guidance — MCP Resources and Prompts (Issue #37)
+
+## Technical Design
+
+### Approach
+
+Deliver the platform's tracing standard through a `iaf://org/tracing-standards` resource (structured JSON, embedded file) and a `tracing-guide` prompt (parameterized by language). Additionally, add `traceExploreUrl` to `app_status` when `IAF_TEMPO_URL` is configured, and update `logging-guide` examples to include trace-log correlation code. Follows the established pattern from issues #30 and #33. Depends on issue #36 (Tempo + OTel Collector deployed).
+
+### Changes Required
+
+**New file: `config/org-standards/tracing-standards.json`** (embedded default):
+```json
+{
+  "version": "1.0",
+  "sdk": "OpenTelemetry",
+  "exporter": "OTLP",
+  "endpointSource": "OTEL_EXPORTER_OTLP_ENDPOINT environment variable — injected automatically by the IAF platform. Never hardcode this value.",
+  "serviceNameSource": "OTEL_SERVICE_NAME environment variable — set to your IAF application name automatically.",
+  "requiredSpanAttributes": [
+    {"name": "http.method",               "description": "HTTP method: GET, POST, etc."},
+    {"name": "http.route",                "description": "Route template: /users/:id, not /users/123"},
+    {"name": "http.status_code",          "description": "HTTP response status code (integer)"},
+    {"name": "http.response_content_length", "description": "Response body size in bytes (optional but recommended)"}
+  ],
+  "traceLogCorrelation": {
+    "description": "Add trace_id and span_id to every structured log line to enable Grafana trace-to-log correlation.",
+    "requiredLogFields": ["trace_id", "span_id"],
+    "howToExtract": "Use the OTel SDK's span context API to read the current trace and span IDs at log time."
+  },
+  "autoInstrumentation": {
+    "nodejs":  "Available — @opentelemetry/auto-instrumentations-node",
+    "python":  "Available — opentelemetry-instrument CLI wrapper",
+    "java":    "Available — opentelemetry-javaagent.jar (-javaagent flag)",
+    "go":      "Not available — manual SDK required",
+    "ruby":    "Available — opentelemetry-instrumentation-all gem"
+  },
+  "securityNote": "Span attributes must never contain secrets, tokens, or PII. Traces are stored and queryable by platform operators.",
+  "verification": "Use app_status to get the traceExploreUrl field (when available) to verify traces are flowing."
+}
+```
+Overridable via `IAF_TRACING_STANDARDS_FILE` env var.
+
+**New file: `internal/mcp/resources/tracing_standards.go`**:
+- `RegisterTracingStandards(server *gomcp.Server, deps *tools.Dependencies)`
+- URI: `iaf://org/tracing-standards`; MIMEType: `application/json`
+- Pattern identical to `logging_standards.go` and `metrics_standards.go`
+
+**New file: `internal/mcp/prompts/tracing_guide.go`**:
+- `RegisterTracingGuide(server *gomcp.Server, deps *tools.Dependencies)`
+- `language` argument; same alias map
+- `tracingGuides` map per language:
+
+  **Node.js** (auto-instrumentation path, then manual):
+  ```
+  npm install @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-http
+  # startup: NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register" node app.js
+  # Reads OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME automatically.
+  ```
+  Trace-log correlation: `pino-opentelemetry` or manual extraction via `trace.getActiveSpan()?.spanContext()`.
+
+  **Python** (auto-instrumentation path, then manual):
+  ```
+  pip install opentelemetry-distro opentelemetry-exporter-otlp
+  opentelemetry-bootstrap -a install
+  # startup: opentelemetry-instrument python app.py
+  ```
+  Trace-log correlation: `opentelemetry-instrumentation-logging` (auto-injects `trace_id` into stdlib `logging`).
+
+  **Java** (auto-instrumentation via javaagent):
+  ```
+  # Download opentelemetry-javaagent.jar
+  # JVM flag: -javaagent:/path/to/opentelemetry-javaagent.jar
+  # Reads OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME automatically.
+  ```
+  Trace-log correlation: logback MDC is auto-populated when using javaagent.
+
+  **Go** (manual only):
+  ```go
+  import "go.opentelemetry.io/otel"
+  import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+  // Init: reads OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME from env
+  exp, _ := otlptracehttp.New(ctx)
+  tp := trace.NewTracerProvider(trace.WithBatcher(exp))
+  otel.SetTracerProvider(tp)
+  ```
+  Trace-log correlation: `span.SpanContext().TraceID().String()` + `span.SpanContext().SpanID().String()`.
+
+  **Ruby** (auto-instrumentation via gem):
+  ```ruby
+  gem 'opentelemetry-sdk', 'opentelemetry-instrumentation-all', 'opentelemetry-exporter-otlp'
+  # In config/initializers/opentelemetry.rb:
+  OpenTelemetry::SDK.configure { |c| c.use_all }
+  # Reads OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME automatically.
+  ```
+  Trace-log correlation: `OpenTelemetry::Trace.current_span.context.trace_id.unpack1('H*')`.
+
+- Each language guide ends with:
+  - "Do not hardcode `OTEL_EXPORTER_OTLP_ENDPOINT`. The platform injects it automatically."
+  - "Never add secrets, tokens, or PII as span attributes."
+  - "Verify: after deploying, call `app_status` and check the `traceExploreUrl` field."
+
+**Updated `internal/mcp/tools/status.go`** (or wherever `app_status` response is built):
+
+```go
+type AppStatusOutput struct {
+    // ... existing fields ...
+    TraceExploreURL string `json:"traceExploreUrl,omitempty"`
+}
+```
+
+When `deps.TempoURL != ""`:
+```go
+// Generate Grafana Explore deep link pre-filtered to this app's service.name
+// URL format: {grafanaURL}/explore?orgId=1&left={"datasource":"Tempo","queries":[{"query":"{service.name=\"<appName>\"}","queryType":"traceql"}],"range":{"from":"now-1h","to":"now"}}
+output.TraceExploreURL = buildTraceExploreURL(deps.TempoURL, app.Name)
+```
+
+`buildTraceExploreURL(grafanaURL, appName string) string`:
+- `appName` is already validated (K8s name rules from issue #14) — use directly in the URL without additional sanitization, but URL-encode the JSON parameter string.
+- The URL is a Grafana Explore deep link; `grafanaURL` comes from `IAF_TEMPO_URL` (platform config, not agent input).
+
+**New field `TempoURL string` on `tools.Dependencies`** — from `IAF_TEMPO_URL` env var.
+
+**Updated `internal/mcp/server.go`**:
+- `resources.RegisterTracingStandards(server, deps)`
+- `prompts.RegisterTracingGuide(server, deps)`
+
+**Updated `config/org-standards/logging-standards.json`** (issue #33 file):
+- `trace_id` and `span_id` promoted from `recommendedFields` to their own `correlationFields` section with note: "Add these when tracing is enabled (OTel SDK present). Required for Grafana trace-to-log correlation."
+
+**Updated `config/org-standards/coding-standards.json`** (issue #1 file):
+- Add `"tracing"` section pointing to `iaf://org/tracing-standards`
+
+**Updated `internal/mcp/prompts/deploy_guide.go`**:
+- Add tracing section: "Tracing: the platform injects `OTEL_EXPORTER_OTLP_ENDPOINT` automatically. Use `tracing-guide` prompt to add OTel to your app."
+
+**Test files**:
+
+`internal/mcp/resources/tracing_standards_test.go`:
+- `TestTracingStandards_ReturnsValidJSON`: verify required keys present
+
+`internal/mcp/prompts/tracing_guide_test.go`:
+- Table-driven: each language guide references correct package name and `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `TestTracingGuide_NoHardcodedEndpoints`: verify no guide contains hardcoded `otel-collector.monitoring` (guides must use env vars)
+
+`internal/mcp/tools/status_test.go` (extend existing):
+- `TestAppStatus_TraceExploreURL_Set`: `deps.TempoURL = "http://grafana.localhost"` → response contains `traceExploreUrl`
+- `TestAppStatus_TraceExploreURL_Absent`: `deps.TempoURL = ""` → `traceExploreUrl` absent from response
+
+### Data / API Changes
+
+- New MCP resource: `iaf://org/tracing-standards`
+- New MCP prompt: `tracing-guide`
+- `app_status` response: new optional `traceExploreUrl` field
+- `tools.Dependencies`: new `TempoURL string` field
+- No CRD changes, no K8s object changes.
+
+### Multi-tenancy & Shared Resource Impact
+
+`iaf://org/tracing-standards` is global and read-only — no tenant data. `traceExploreUrl` is generated server-side from the app's validated name and namespace — no cross-tenant leakage. The Grafana Explore link opens a view scoped to this app's `service.name`; it relies on Grafana authentication to prevent unauthorized access.
+
+### Security Considerations
+
+- **`traceExploreUrl` generation**: `appName` comes from the validated `Application` CR name (K8s name rules). `grafanaURL` comes from `IAF_TEMPO_URL` — platform config, not agent input. The JSON parameter is URL-encoded. No injection risk.
+- **Guide content**: every language guide explicitly warns "Never add secrets, tokens, or PII as span attributes." This is the tracing equivalent of the logging prohibition.
+- **Auto-instrumentation scope**: the guide recommends auto-instrumentation (zero code changes). Auto-instrumentation traces HTTP headers, SQL queries, and outbound requests — these can contain sensitive data. Agents must review what their OTel SDK auto-instruments and disable sensitive instrumentation if needed (e.g., `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS=false`). Add this note to the guide.
+
+### Resource & Performance Impact
+
+- New MCP resource and prompt: in-memory, negligible.
+- `buildTraceExploreURL` is a string operation per `app_status` call — negligible.
+
+### Migration / Compatibility
+
+- `traceExploreUrl` is optional — existing `app_status` callers unaffected.
+- `TempoURL = ""` = no URL in response = zero behavior change.
+- Depends on issue #36 (Tempo deployed) for the `traceExploreUrl` to actually work, but the code can ship independently.
+
+### Open Questions for Developer
+
+1. **Grafana Explore URL format**: the URL format for Tempo datasource explore links changed between Grafana 10 and 11. Confirm the exact format for the kube-prometheus-stack Grafana version pinned in issue #29. Use the TraceQL format: `{service.name="<appName>"}`.
+2. **`IAF_TEMPO_URL` value**: this should be the Grafana base URL (e.g., `http://grafana.localhost`), not the Tempo backend URL. The explore link is a Grafana UI link, not a Tempo API link. Name the env var accordingly to avoid confusion with `IAF_LOKI_URL` (which points to the Loki API).
+3. **Auto-instrumentation and `Dockerfile`**: for Node.js and Python, auto-instrumentation requires modifying the startup command (add `--require` or `opentelemetry-instrument`). Since IAF uses Cloud Native Buildpacks, agents can set the startup command via the `Procfile`. Add this note to the Node.js and Python guides.
+4. **`TestTracingGuide_NoHardcodedEndpoints` test**: use a regex or string search for `otel-collector.monitoring` in the guide text to catch accidental hardcoding. This is a correctness requirement, not just a style check.


### PR DESCRIPTION
## Summary

Full observability stack design for IAF, managed via **Helmfile** for easy install and upgrades (`helmfile apply -f config/helmfile.yaml`):

- **Issue #29**: kube-prometheus-stack (Prometheus + Grafana) via Helmfile; `ServiceMonitor` per app; platform metrics instrumentation; Grafana dashboards via ConfigMap
- **Issue #30**: `iaf://org/metrics-standards` resource + `metrics-guide` prompt; RED method standard; `deploy_app` metrics parameter; Deployment label injection
- **Issue #31**: Loki + Grafana Alloy via Helmfile; `app_logs` Loki integration with `since` parameter; platform JSON structured logging
- **Issue #33**: `iaf://org/logging-standards` resource + `logging-guide` prompt; NDJSON/stdout standard per language; secret logging prohibition
- **Issue #36**: Grafana Tempo + OTel Collector via Helmfile; OTel env var injection per Deployment; platform OTel SDK instrumentation
- **Issue #37**: `iaf://org/tracing-standards` resource + `tracing-guide` prompt; `traceExploreUrl` in `app_status`; trace-log correlation guidance

Issues #29, #31, #36 tagged `needs-security-review` for Prometheus/Loki/OTel RBAC and multi-tenant isolation review.

## Test plan

- [ ] Review Helmfile structure in issue #29 doc
- [ ] Review metrics/logging/tracing standard JSON files in #30, #33, #37 docs
- [ ] Verify namespace isolation controls for Loki (#31) and Tempo (#36)
- [ ] Review OTel Collector RBAC in #36 doc
- [ ] Confirm no hardcoded endpoints in tracing guide (#37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)