### PR TITLE
Fix mcpserver log streaming (Issue #9)

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp_test
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,10 @@ import (
 	"github.com/dlapiduz/iaf/internal/sourcestore"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -270,5 +274,125 @@ func TestNewServer_WithoutGitHub_NoGitHubComponents(t *testing.T) {
 		if p.Name == "github-guide" {
 			t.Error("expected 'github-guide' to NOT be registered without GitHub config")
 		}
+	}
+}
+
+// setupServerForLogs creates a server+k8sClient pair, optionally wiring a
+// fake Kubernetes clientset for log streaming.
+func setupServerForLogs(t *testing.T, withClientset bool) (*gomcp.ClientSession, ctrlclient.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	_ = iafv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	store, err := sourcestore.New(t.TempDir(), "http://localhost:8080", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := auth.NewSessionStore(filepath.Join(t.TempDir(), "sessions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var server *gomcp.Server
+	if withClientset {
+		cs := k8sfake.NewSimpleClientset()
+		server = iafmcp.NewServer(k8sClient, sessions, store, "test.example.com", nil, nil, "", "", cs)
+	} else {
+		server = iafmcp.NewServer(k8sClient, sessions, store, "test.example.com", nil, nil, "", "")
+	}
+
+	st, ct := gomcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatal(err)
+	}
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { clientSession.Close() })
+	return clientSession, k8sClient
+}
+
+func TestAppLogs_DegradedWithoutClientset(t *testing.T) {
+	cs, k8sClient := setupServerForLogs(t, false)
+	ctx := context.Background()
+
+	regRes, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "register",
+		Arguments: map[string]any{"name": "test"},
+	})
+	if err != nil || regRes.IsError {
+		t.Fatal("register failed")
+	}
+	var reg map[string]any
+	_ = json.Unmarshal([]byte(regRes.Content[0].(*gomcp.TextContent).Text), &reg)
+	sid := reg["session_id"].(string)
+	namespace := reg["namespace"].(string)
+
+	app := &iafv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: namespace},
+		Spec:       iafv1alpha1.ApplicationSpec{Image: "nginx:latest", Port: 8080, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("creating app: %v", err)
+	}
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "app_logs",
+		Arguments: map[string]any{"session_id": sid, "name": "myapp"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(*gomcp.TextContent).Text
+	if !strings.Contains(text, "kubernetes clientset") {
+		t.Errorf("degraded mode should mention 'kubernetes clientset', got: %s", text)
+	}
+}
+
+func TestAppLogs_EnabledWithClientset(t *testing.T) {
+	cs, k8sClient := setupServerForLogs(t, true)
+	ctx := context.Background()
+
+	regRes, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "register",
+		Arguments: map[string]any{"name": "test"},
+	})
+	if err != nil || regRes.IsError {
+		t.Fatal("register failed")
+	}
+	var reg map[string]any
+	_ = json.Unmarshal([]byte(regRes.Content[0].(*gomcp.TextContent).Text), &reg)
+	sid := reg["session_id"].(string)
+	namespace := reg["namespace"].(string)
+
+	app := &iafv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: namespace},
+		Spec:       iafv1alpha1.ApplicationSpec{Image: "nginx:latest", Port: 8080, Replicas: 1},
+	}
+	if err := k8sClient.Create(ctx, app); err != nil {
+		t.Fatalf("creating app: %v", err)
+	}
+
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "app_logs",
+		Arguments: map[string]any{"session_id": sid, "name": "myapp"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(*gomcp.TextContent).Text
+	// With a clientset wired in, the degraded message must NOT appear
+	if strings.Contains(text, "kubernetes clientset") {
+		t.Errorf("enabled mode should not contain degraded message, got: %s", text)
+	}
+	// No pods exist in the fake clientset so we expect "No pods found"
+	if !strings.Contains(text, "No pods found") {
+		t.Errorf("expected 'No pods found' with no pods, got: %s", text)
 	}
 }


### PR DESCRIPTION
## Summary

- `cmd/mcpserver/main.go` now creates a `kubernetes.Clientset` using `k8s.GetConfig` + `kubernetes.NewForConfig` and passes it to `iafmcp.NewServer`
- On success: logs `"log streaming: enabled"` and registers `RegisterAppLogsWithClientset`
- On failure (no kubeconfig): logs a warning and falls back to the degraded `RegisterAppLogs` — all other tools still work
- No changes to `internal/mcp/server.go` — the existing variadic clientset parameter handles both paths

Closes #9

## Test plan
- [ ] `TestAppLogs_DegradedWithoutClientset` — degraded message appears when no clientset
- [ ] `TestAppLogs_EnabledWithClientset` — "No pods found" (real path) when clientset provided
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)