### PR TITLE
fix(services): deprovision_service handles stale BoundApps after app deletion

### DIFF
--- a/internal/mcp/tools/services.go
+++ b/internal/mcp/tools/services.go
@@ -327,9 +327,26 @@ func RegisterDeprovisionService(server *gomcp.Server, deps *Dependencies) {
 			return nil, nil, fmt.Errorf("getting service: %w", err)
 		}
 
-		// UX guard: check bound apps. The controller finalizer is the security boundary.
+		// UX guard: check bound apps. Filter out any apps that no longer exist (e.g.
+		// deleted before unbind_service was called) to avoid a permanent deadlock.
 		if len(svc.Status.BoundApps) > 0 {
-			return nil, nil, fmt.Errorf("service %q is still bound to applications %v — use unbind_service to remove all bindings before deprovisioning", input.Name, svc.Status.BoundApps)
+			var stillBound []string
+			for _, appName := range svc.Status.BoundApps {
+				var app iafv1alpha1.Application
+				err := deps.Client.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, &app)
+				if err == nil {
+					stillBound = append(stillBound, appName)
+				}
+				// app not found → stale entry, skip it
+			}
+			if len(stillBound) > 0 {
+				return nil, nil, fmt.Errorf("service %q is still bound to applications %v — use unbind_service to remove all bindings before deprovisioning", input.Name, stillBound)
+			}
+			// All bound apps are gone — clear the stale list so the controller can proceed.
+			svc.Status.BoundApps = nil
+			if err := deps.Client.Status().Update(ctx, &svc); err != nil {
+				return nil, nil, fmt.Errorf("clearing stale bound apps: %w", err)
+			}
 		}
 
 		if err := deps.Client.Delete(ctx, &svc); err != nil {

--- a/internal/mcp/tools/services_test.go
+++ b/internal/mcp/tools/services_test.go
@@ -637,6 +637,13 @@ func TestDeprovisionService_Blocked(t *testing.T) {
 	sid := regData["session_id"].(string)
 	ns := regData["namespace"].(string)
 
+	// Create the Application CR so the binding check sees it as truly bound.
+	app := &iafv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: ns},
+		Spec:       iafv1alpha1.ApplicationSpec{Image: "nginx:latest", Port: 8080, Replicas: 1},
+	}
+	k8sClient.Create(ctx, app)
+
 	svc := &iafv1alpha1.ManagedService{
 		ObjectMeta: metav1.ObjectMeta{Name: "pgdb", Namespace: ns},
 		Spec:       iafv1alpha1.ManagedServiceSpec{Type: "postgres", Plan: "micro"},
@@ -712,5 +719,65 @@ func TestDeprovisionService_OK(t *testing.T) {
 	err = k8sClient.Get(ctx, types.NamespacedName{Name: "pgdb", Namespace: ns}, &check)
 	if err == nil {
 		t.Error("expected ManagedService to be deleted")
+	}
+}
+
+// TestDeprovisionService_StaleBinding verifies that deprovision_service succeeds when
+// BoundApps lists an app that no longer exists (deleted before unbind_service was called).
+func TestDeprovisionService_StaleBinding(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	_ = iafv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&iafv1alpha1.ManagedService{}).
+		Build()
+
+	store, _ := sourcestore.New(t.TempDir(), "http://localhost:8080", slog.Default())
+	sessions, _ := auth.NewSessionStore(filepath.Join(t.TempDir(), "sessions.json"))
+	deps := &tools.Dependencies{
+		Client:     k8sClient,
+		Store:      store,
+		BaseDomain: "test.example.com",
+		Sessions:   sessions,
+	}
+
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	tools.RegisterRegisterTool(server, deps)
+	tools.RegisterDeprovisionService(server, deps)
+
+	st, ct := gomcp.NewInMemoryTransports()
+	server.Connect(ctx, st, nil)
+	cl := gomcp.NewClient(&gomcp.Implementation{Name: "tc", Version: "0.0.1"}, nil)
+	cs, _ := cl.Connect(ctx, ct, nil)
+	t.Cleanup(func() { cs.Close() })
+
+	regRes, _ := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name: "register", Arguments: map[string]any{"name": "a"},
+	})
+	var regData map[string]any
+	json.Unmarshal([]byte(regRes.Content[0].(*gomcp.TextContent).Text), &regData)
+	sid := regData["session_id"].(string)
+	ns := regData["namespace"].(string)
+
+	// Service has a BoundApps entry for "ghost-app" which does not exist as an Application CR.
+	svc := &iafv1alpha1.ManagedService{
+		ObjectMeta: metav1.ObjectMeta{Name: "pgdb", Namespace: ns},
+		Spec:       iafv1alpha1.ManagedServiceSpec{Type: "postgres", Plan: "micro"},
+		Status:     iafv1alpha1.ManagedServiceStatus{BoundApps: []string{"ghost-app"}},
+	}
+	k8sClient.Create(ctx, svc)
+	k8sClient.Status().Update(ctx, svc)
+
+	// Deprovision should succeed — "ghost-app" is gone, so the binding is stale.
+	res, err := cs.CallTool(ctx, &gomcp.CallToolParams{
+		Name:      "deprovision_service",
+		Arguments: map[string]any{"session_id": sid, "name": "pgdb"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("expected deprovision_service to succeed with stale binding, got err=%v isError=%v text=%v",
+			err, res.IsError, res.Content)
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes a deadlock where `deprovision_service` blocked on an app that no longer existed
- When an app is deleted before `unbind_service` is called, `svc.Status.BoundApps` retains a stale entry
- `deprovision_service` now checks whether each listed app actually exists as an Application CR
- Stale entries (app deleted) are cleared via a Status patch; truly bound apps still block deletion
- Adds `TestDeprovisionService_StaleBinding` to cover the race condition
- Updates `TestDeprovisionService_Blocked` to create the Application CR (required for the binding check to work correctly)

## Root cause

```
deprovision_service("event-db") → blocked: BoundApps=["event-checkin"]
unbind_service(app="event-checkin") → error: application not found
deprovision_service("event-db") → still blocked (stale entry never cleared)
```

## Test plan
- [x] `go test ./...` passes
- [x] `TestDeprovisionService_StaleBinding` — deprovisioning succeeds when bound app is gone
- [x] `TestDeprovisionService_Blocked` — deprovisioning still blocked when app exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)